### PR TITLE
helm: allow cdi path configuration

### DIFF
--- a/helm-charts-k8s/templates/kubeletplugin.yaml
+++ b/helm-charts-k8s/templates/kubeletplugin.yaml
@@ -97,7 +97,7 @@ spec:
           path: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
       - name: cdi
         hostPath:
-          path: /var/run/cdi
+          path: {{ .Values.cdi.dynamicPath }}
       - name: dev
         hostPath:
           path: /dev

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -92,3 +92,6 @@ webhook:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+
+cdi:
+  dynamicPath: /var/run/cdi


### PR DESCRIPTION
Some environments require this to be a specific path. This makes the value configurable.