### PR TITLE
Add NUMA node attribute to GPU ResourceSlices

### DIFF
--- a/cmd/gpu-kubeletplugin/deviceinfo.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo.go
@@ -40,6 +40,7 @@ type AmdGpuInfo struct {
 	MemoryBytes      uint64
 	ComputeUnits     int
 	SimdUnits        int
+	NumaNode         int
 	// PCIe root attribute for topology awareness
 	pcieRootAttr deviceattribute.DeviceAttribute
 }
@@ -54,6 +55,7 @@ type AmdPartitionInfo struct {
 	MemoryBytes      uint64
 	ComputeUnits     int
 	SimdUnits        int
+	NumaNode         int
 }
 
 // CanonicalName returns the canonical name for this GPU
@@ -93,6 +95,9 @@ func (d *AmdGpuInfo) GetDevice() resourceapi.Device {
 		},
 		"partitionProfile": {
 			StringValue: ptr.To(d.PartitionProfile),
+		},
+		"numaNode": {
+			IntValue: ptr.To(int64(d.NumaNode)),
 		},
 	}
 
@@ -155,6 +160,9 @@ func (d *AmdPartitionInfo) GetDevice() resourceapi.Device {
 		},
 		"partitionProfile": {
 			StringValue: ptr.To(d.PartitionProfile),
+		},
+		"numaNode": {
+			IntValue: ptr.To(int64(d.NumaNode)),
 		},
 	}
 

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -116,6 +116,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 				pcieRootAttr:     pcieRootAttr,
 				SimdUnits:        simdUnits,
 				ComputeUnits:     computeUnits,
+				NumaNode:         gpuInfoMap["numaNode"].(int),
 				MemoryBytes:      getMemoryBytes(gpuInfoMap, 80*1024*1024*1024, "device", pciAddr),
 			}
 
@@ -149,6 +150,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 				PartitionProfile: fmt.Sprintf("%s_%s", computePartitionType, memoryPartitionType),
 				SimdUnits:        simdUnits,
 				ComputeUnits:     computeUnits,
+				NumaNode:         gpuInfoMap["numaNode"].(int),
 				MemoryBytes:      getMemoryBytes(gpuInfoMap, 20*1024*1024*1024, "partition", pciAddr),
 			}
 

--- a/docs/driver-attributes.md
+++ b/docs/driver-attributes.md
@@ -40,6 +40,7 @@ The following attributes are attached to each full GPU device:
 - `partitionProfile` (string): For platforms that support partitioning, the
   current compute+memory profile (e.g., `spx_<mem>`); may be empty on devices
   that do not use partitioning
+- `numaNode` (int): NUMA node the GPU is attached to (read from sysfs)
 - Topology attribute: a PCIe root attribute is included when
   derivable; its qualified name and value come from the Kubernetes
   `deviceattribute` library and can be used by schedulers/topology-aware logic
@@ -67,6 +68,7 @@ The following attributes are attached to each GPU partition device:
 - `driverVersion` (semver): inherited from parent
 - `driverSrcVersion` (string): inherited from parent
 - `partitionProfile` (string): compute+memory profile of the partition
+- `numaNode` (int): NUMA node inherited from the parent GPU
 - Optional topology attribute: the parent’s PCIe root attribute is propagated
 
 Capacity values for partitions:
@@ -150,6 +152,44 @@ Notes:
 - If you instead want partitions from DIFFERENT parents, use
   `constraints.distinctAttribute: deviceID` across the requests.
 
+## NUMA-aware GPU scheduling
+
+The `numaNode` attribute reports the NUMA node each GPU is attached to. Use it
+to co-locate GPUs on the same NUMA node and reduce memory-access latency for
+CPU–GPU workloads.
+
+The recommended pattern is `constraints.matchAttribute` — the scheduler picks
+any NUMA node but guarantees every matched request lands on the same one:
+
+```yaml
+spec:
+  devices:
+    requests:
+      - name: g0
+        deviceClassName: gpu.amd.com
+      - name: g1
+        deviceClassName: gpu.amd.com
+      - name: g2
+        deviceClassName: gpu.amd.com
+      - name: g3
+        deviceClassName: gpu.amd.com
+    constraints:
+      - matchAttribute: gpu.amd.com/numaNode
+        requests: ["g0", "g1", "g2", "g3"]
+```
+
+See `example/example-numa-aligned-gpus.yaml` for a complete working example
+that uses this pattern to run two tensor-parallel vLLM replicas, each pinned to
+a single NUMA node.
+
+If you need GPUs from a *specific* NUMA node, add a CEL selector instead:
+
+```yaml
+selectors:
+  - cel:
+      expression: 'device.attributes["gpu.amd.com"].numaNode == 0'
+```
+
 ## Current capabilities and notes
 
 - Discovery: the driver walks the relevant sysfs paths to find AMD GPUs and
@@ -161,6 +201,8 @@ Notes:
   attributes such as `pciAddr` and `deviceID`.
 - Topology hinting: a PCIe root attribute is added when derivable, enabling
   topology-aware scheduling.
+- NUMA node discovery: the driver reads the NUMA node for each GPU from sysfs
+  and exposes it as an integer attribute for NUMA-aware scheduling.
 - Defaults: when certain metrics (like VRAM) cannot be read reliably, the
   driver falls back to conservative defaults to remain usable. These values can
   differ from the exact hardware amounts and are best used as coarse selectors.

--- a/example/example-numa-aligned-gpus.yaml
+++ b/example/example-numa-aligned-gpus.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-test
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: gpu-test
+  name: vllm-4gpu-numa-aligned
+spec:
+  spec:
+    devices:
+      requests:
+        - name: g0
+          exactly:
+            deviceClassName: gpu.amd.com
+        - name: g1
+          exactly:
+            deviceClassName: gpu.amd.com
+        - name: g2
+          exactly:
+            deviceClassName: gpu.amd.com
+        - name: g3
+          exactly:
+            deviceClassName: gpu.amd.com
+      constraints:
+        - matchAttribute: gpu.amd.com/numaNode
+          requests: ["g0", "g1", "g2", "g3"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-dp2-tp4
+  namespace: gpu-test
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: vllm-dp2-tp4
+  template:
+    metadata:
+      labels:
+        app: vllm-dp2-tp4
+    spec:
+      tolerations:
+        - key: amd.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: vllm
+          image: rocm/vllm:rocm7.0.0_vllm_0.11.2_20251210
+          securityContext:
+            capabilities:
+              add: ["SYS_PTRACE", "IPC_LOCK"]
+          env:
+            - name: HF_HOME
+              value: /hf-cache
+            - name: NCCL_DEBUG
+              value: WARN
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen2.5-7B-Instruct"
+            - "--tensor-parallel-size=4"
+            - "--host=0.0.0.0"
+            - "--port=8000"
+          ports:
+            - containerPort: 8000
+              name: http
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /hf-cache
+            - name: dshm
+              mountPath: /dev/shm
+          resources:
+            claims:
+              - name: gpus
+      volumes:
+        - name: hf-cache
+          emptyDir: {}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+      resourceClaims:
+        - name: gpus
+          resourceClaimTemplateName: vllm-4gpu-numa-aligned
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-dp2-tp4
+  namespace: gpu-test
+spec:
+  selector:
+    app: vllm-dp2-tp4
+  ports:
+    - port: 8000
+      targetPort: 8000


### PR DESCRIPTION
## Summary
- Publish each GPU's NUMA node as an integer attribute (`numaNode`) in the ResourceSlice
- Enables NUMA-aware scheduling using CEL selectors such as:
  `device.attributes["gpu.amd.com"].numaNode == 0`
- Includes an example workload that requests NUMA-aligned GPUs from the same NUMA domain

## Details
The `numaNode` attribute is read from the GPU info map during device enumeration and published as an `IntValue` attribute on both full GPU devices and GPU partitions. This allows cluster administrators to write DeviceClass or ResourceClaim selectors that constrain GPU allocation to a specific NUMA node, improving memory locality for latency-sensitive workloads.

## Note
To deploy on Kubernetes 1.34+ clusters (which no longer serve the `v1beta1` DRA API), the Helm chart changes in #13 are required. That PR adds dynamic DRA API version detection and should be merged independently.

## Test plan
- [x] Deployed on a K8s 1.34 cluster with 8x MI325X GPUs
- [x] Verified all 8 GPUs discovered with correct `numaNode` values (4 on NUMA 0, 4 on NUMA 1)
- [x] Verified NUMA-aligned scheduling: 2 pods each allocated 4 GPUs from the same NUMA node