### PR TITLE
[Fix] Combine locationID and domain as combined devID to detect partitioned GPU

### DIFF
--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -425,10 +425,11 @@ type TopologyInfo struct {
 }
 
 var topoDrmRenderMinorRe = regexp.MustCompile(`drm_render_minor\s(\d+)`)
-var topoUniqueIdRe = regexp.MustCompile(`unique_id\s(\d+)`)
 var topoSimdCountRe = regexp.MustCompile(`simd_count\s(\d+)`)
 var topoSimdPerCuRe = regexp.MustCompile(`simd_per_cu\s(\d+)`)
 var topoSizeInBytesRe = regexp.MustCompile(`size_in_bytes\s(\d+)`)
+var topoLocationIdRe = regexp.MustCompile(`location_id\s(\d+)`)
+var topoDomainRe = regexp.MustCompile(`domain\s(\d+)`)
 
 // GetTopologyInfo returns comprehensive topology information for all render devices
 // This combines the functionality of GetDevIdsFromTopology and GetNodeIdsFromTopology
@@ -462,11 +463,22 @@ func GetTopologyInfo(topoRootParam ...string) map[int]*TopologyInfo {
 		}
 
 		// Parse unique ID
-		uniqueID, e := ParseTopologyPropertiesString(nodeFile, topoUniqueIdRe)
+		locationId, e := ParseTopologyProperties(nodeFile, topoLocationIdRe)
 		if e != nil {
 			glog.Error(e)
 			continue
 		}
+
+		// Parse domain
+		domain, e := ParseTopologyProperties(nodeFile, topoDomainRe)
+		if e != nil {
+			glog.Error(e)
+			continue
+		}
+
+		dev := (locationId >> 3) & 0x1f
+		bus := (locationId >> 8) & 0xff
+		devID := fmt.Sprintf("%04x:%02x:%02x:0", domain, bus, dev)
 
 		// Extract node ID from file path
 		nodeIndex := filepath.Base(filepath.Dir(nodeFile))
@@ -511,7 +523,7 @@ func GetTopologyInfo(topoRootParam ...string) map[int]*TopologyInfo {
 		// Create topology info structure
 		topologyInfoMap[int(renderMinor)] = &TopologyInfo{
 			RenderDeviceID: int(renderMinor),
-			UniqueID:       uniqueID,
+			UniqueID:       devID,
 			NodeID:         nodeId,
 			SimdCount:      int(simdCount),
 			SimdPerCU:      int(simdPerCU),


### PR DESCRIPTION


## Motivation

Previously the driver would make one physical GPU's partitioned device has the same uniqueID and that is what we depend on to detect partitioned GPU. Now the latest driver changed this behavior and make each partitioned GPU a different uniqueID, hence the partitioned GPU detection is not working anymore.

Related issue: #20 

## Technical Details

We need to find another way, which is combining the locationID and domain to use as a ID for detecting the partitioned GPUs that belong to the same physical GPU.

Cherry-picked from https://github.com/ROCm/k8s-device-plugin/pull/162 that is the fix on device plugin side, has to manually cherry-pick due to many conflicts.

## Test Plan

Use a 8 Mi300X GPU node, perform a DPX partition test, 16 GPUs shows up from amd-smi
Verify the fix and compare the resourceSlice reporting with existing image and patched image with this PR's fix.

## Test Result
Without the fix it shows 8 GPUs
With the fix it shows 16 GPUs

* Before:
```
apiVersion: resource.k8s.io/v1beta1
kind: ResourceSlice
metadata:
  creationTimestamp: "2026-03-10T22:44:02Z"
  generateName: gpu-operator-2-gpu.amd.com-
  generation: 1
  name: gpu-operator-2-gpu.amd.com-fk4fq
  ownerReferences:
  - apiVersion: v1
    controller: true
    kind: Node
    name: gpu-operator-2
    uid: 48a17ac9-90ac-4b1c-8214-4448e27a6830
  resourceVersion: "50087685"
  uid: 8b60821c-932a-43b9-b11f-32c7bcf2389d
spec:
  devices:
  - basic:
      attributes:
        cardIndex:
          int: 32
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "7066866330502360227"
        parentPciAddr:
          string: "0003:00:01.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 160
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-32-160
  - basic:
      attributes:
        cardIndex:
          int: 40
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "14942620774049468118"
        parentPciAddr:
          string: "0003:00:02.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 168
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-40-168
  - basic:
      attributes:
        cardIndex:
          int: 48
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "9769175250215851363"
        parentPciAddr:
          string: "0003:00:03.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 176
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-48-176
  - basic:
      attributes:
        cardIndex:
          int: 56
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "17953628401758467531"
        parentPciAddr:
          string: "0003:00:04.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 184
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-56-184
  - basic:
      attributes:
        cardIndex:
          int: 0
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "12454742256355029426"
        parentPciAddr:
          string: "0002:00:01.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 128
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-0-128
  - basic:
      attributes:
        cardIndex:
          int: 8
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "63830013102444050"
        parentPciAddr:
          string: "0002:00:02.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 136
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-8-136
  - basic:
      attributes:
        cardIndex:
          int: 16
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "14746335210068429714"
        parentPciAddr:
          string: "0002:00:03.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 144
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-16-144
  - basic:
      attributes:
        cardIndex:
          int: 24
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        parentDeviceID:
          string: "12600847414121220730"
        parentPciAddr:
          string: "0002:00:04.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 152
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-24-152
  driver: gpu.amd.com
  nodeName: gpu-operator-2
  pool:
    generation: 1
    name: gpu-operator-2
    resourceSliceCount: 1
```
* After:
```
apiVersion: resource.k8s.io/v1beta1
kind: ResourceSlice
metadata:
  creationTimestamp: "2026-03-10T22:45:18Z"
  generateName: gpu-operator-2-gpu.amd.com-
  generation: 1
  name: gpu-operator-2-gpu.amd.com-f8fgq
  ownerReferences:
  - apiVersion: v1
    controller: true
    kind: Node
    name: gpu-operator-2
    uid: 48a17ac9-90ac-4b1c-8214-4448e27a6830
  resourceVersion: "50087858"
  uid: 779c028f-955e-4cbd-a5cd-8b91d45e88f4
spec:
  devices:
  - basic:
      attributes:
        cardIndex:
          int: 17
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:03:0"
        parentPciAddr:
          string: "0002:00:03.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 145
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-17-145
  - basic:
      attributes:
        cardIndex:
          int: 16
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:03:0"
        parentPciAddr:
          string: "0002:00:03.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 144
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-16-144
  - basic:
      attributes:
        cardIndex:
          int: 1
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:01:0"
        parentPciAddr:
          string: "0002:00:01.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 129
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-1-129
  - basic:
      attributes:
        cardIndex:
          int: 25
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:04:0"
        parentPciAddr:
          string: "0002:00:04.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 153
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-25-153
  - basic:
      attributes:
        cardIndex:
          int: 8
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:02:0"
        parentPciAddr:
          string: "0002:00:02.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 136
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-8-136
  - basic:
      attributes:
        cardIndex:
          int: 48
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:03:0"
        parentPciAddr:
          string: "0003:00:03.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 176
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-48-176
  - basic:
      attributes:
        cardIndex:
          int: 49
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:03:0"
        parentPciAddr:
          string: "0003:00:03.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 177
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-49-177
  - basic:
      attributes:
        cardIndex:
          int: 56
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:04:0"
        parentPciAddr:
          string: "0003:00:04.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 184
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-56-184
  - basic:
      attributes:
        cardIndex:
          int: 33
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:01:0"
        parentPciAddr:
          string: "0003:00:01.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 161
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-33-161
  - basic:
      attributes:
        cardIndex:
          int: 41
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:02:0"
        parentPciAddr:
          string: "0003:00:02.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 169
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-41-169
  - basic:
      attributes:
        cardIndex:
          int: 9
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:02:0"
        parentPciAddr:
          string: "0002:00:02.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 137
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-9-137
  - basic:
      attributes:
        cardIndex:
          int: 57
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:04:0"
        parentPciAddr:
          string: "0003:00:04.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 185
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-57-185
  - basic:
      attributes:
        cardIndex:
          int: 24
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:04:0"
        parentPciAddr:
          string: "0002:00:04.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 152
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-24-152
  - basic:
      attributes:
        cardIndex:
          int: 40
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:02:0"
        parentPciAddr:
          string: "0003:00:02.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 168
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-40-168
  - basic:
      attributes:
        cardIndex:
          int: 32
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 1
        parentDeviceID:
          string: "0003:00:01:0"
        parentPciAddr:
          string: "0003:00:01.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 160
        resource.kubernetes.io/pcieRoot:
          string: pci0003:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-32-160
  - basic:
      attributes:
        cardIndex:
          int: 0
        driverSrcVersion:
          string: A27BF33B4586326D747C9FB
        driverVersion:
          version: 6.16.6
        family:
          string: AI
        numaNode:
          int: 0
        parentDeviceID:
          string: "0002:00:01:0"
        parentPciAddr:
          string: "0002:00:01.0"
        partitionProfile:
          string: dpx_nps1
        productName:
          string: AMD_Instinct_MI300X_OAM
        renderIndex:
          int: 128
        resource.kubernetes.io/pcieRoot:
          string: pci0002:00
        type:
          string: amdgpu-partition
      capacity:
        computeUnits:
          value: "152"
        memory:
          value: 98296Mi
        simdUnits:
          value: "608"
    name: gpu-0-128
  driver: gpu.amd.com
  nodeName: gpu-operator-2
  pool:
    generation: 1
    name: gpu-operator-2
    resourceSliceCount: 1
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
