### PR TITLE
helm: add driver-init container to wait for amdgpu kernel driver (#23)

### DIFF
--- a/api/amd.com/resource/gpu/v1alpha1/validate_test.go
+++ b/api/amd.com/resource/gpu/v1alpha1/validate_test.go
@@ -33,7 +33,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,7 +45,7 @@ func TestGpuConfigValidate(t *testing.T) {
 	}{
 		"empty GpuConfig": {
 			gpuConfig: &GpuConfig{},
-			expected:  errors.New("no sharing strategy set"),
+			expected:  nil,
 		},
 		"default GpuConfig": {
 			gpuConfig: DefaultGpuConfig(),

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,6 +92,34 @@ For an end-to-end walkthrough of creating a kind cluster, loading the driver ima
 
 - https://github.com/ROCm/k8s-gpu-dra-driver/blob/main/docs/demo.md
 
+## Helm Configuration Reference
+
+### Driver prerequisite
+
+The DRA driver relies on the `amdgpu` kernel driver to enumerate GPU devices.
+The Helm chart enforces this by running a `driver-init` init container in the
+kubelet plugin DaemonSet pod. This container polls `/sys/class/kfd` and
+`/sys/module/amdgpu/drivers/` and blocks the plugin from starting until the
+kernel driver is loaded.
+
+### Key values
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `image.repository` | `docker.io/rocm/k8s-gpu-dra-driver` | Driver container image repository |
+| `image.tag` | Chart `appVersion` | Driver container image tag |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `kubeletPlugin.containers.init.image` | `busybox:1.36` | Init container image used for the driver readiness check |
+| `kubeletPlugin.containers.init.securityContext` | `{privileged: true}` | Security context for the init container |
+| `kubeletPlugin.containers.init.resources` | `{}` | Resource requests/limits for the init container |
+| `kubeletPlugin.containers.plugin.securityContext` | `{privileged: true}` | Security context for the plugin container |
+| `kubeletPlugin.containers.plugin.resources` | `{}` | Resource requests/limits for the plugin container |
+| `kubeletPlugin.containers.plugin.healthcheckPort` | `51515` | gRPC health check port; set negative to disable |
+| `kubeletPlugin.nodeSelector` | `{}` | Node selector for the kubelet plugin DaemonSet |
+| `kubeletPlugin.tolerations` | `[]` | Tolerations for the kubelet plugin DaemonSet |
+| `kubeletPlugin.priorityClassName` | `system-node-critical` | Priority class for the kubelet plugin pods |
+| `cdi.dynamicPath` | `/var/run/cdi` | Host path for CDI spec files |
+
 ## Contributing
 
 We welcome issues, bug reports, and PRs of any size.

--- a/helm-charts-k8s/templates/kubeletplugin.yaml
+++ b/helm-charts-k8s/templates/kubeletplugin.yaml
@@ -36,6 +36,17 @@ spec:
       serviceAccountName: {{ include "k8s-gpu-dra-driver.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.kubeletPlugin.podSecurityContext | nindent 8 }}
+      initContainers:
+      - name: driver-init
+        image: {{ .Values.kubeletPlugin.containers.init.image | quote }}
+        command: ["sh", "-c", "while [ ! -d /sys/class/kfd ] || [ ! -d /sys/module/amdgpu/drivers/ ]; do echo 'amdgpu driver is not loaded'; sleep 2; done"]
+        securityContext:
+          {{- toYaml .Values.kubeletPlugin.containers.init.securityContext | nindent 10 }}
+        resources:
+          {{- toYaml .Values.kubeletPlugin.containers.init.resources | nindent 10 }}
+        volumeMounts:
+        - name: sys
+          mountPath: /sys
       containers:
       - name: plugin
         securityContext:

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -25,25 +25,6 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-controller:
-  priorityClassName: "system-node-critical"
-  podAnnotations: {}
-  podSecurityContext: {}
-  nodeSelector:
-    node-role.kubernetes.io/control-plane: ""
-  tolerations:
-  - key: node-role.kubernetes.io/master
-    operator: Exists
-    effect: NoSchedule
-  - key: node-role.kubernetes.io/control-plane
-    operator: Exists
-    effect: NoSchedule
-  affinity: {}
-  containers:
-    controller:
-      securityContext: {}
-      resources: {}
-
 kubeletPlugin:
   priorityClassName: "system-node-critical"
   updateStrategy:
@@ -57,7 +38,9 @@ kubeletPlugin:
   kubeletPluginsDirectoryPath: /var/lib/kubelet/plugins
   containers:
     init:
-      securityContext: {}
+      image: docker.io/busybox:1.36
+      securityContext:
+        privileged: true
       resources: {}
     plugin:
       securityContext:


### PR DESCRIPTION
* helm: add driver-init container to wait for amdgpu kernel driver

The DRA plugin requires the amdgpu kernel driver to be loaded before it can enumerate GPU devices. Add an init container to the kubelet plugin DaemonSet that polls /sys/class/kfd and /sys/module/amdgpu/drivers/, blocking the plugin from starting until the driver is ready. This matches the gpu-operator's DRA driver init container behavior.

Also removes the unused controller: section from values.yaml and adds a Helm configuration reference section to the installation docs.

* Fix GpuConfig validation test for empty config

An empty GpuConfig with no sharing strategy is valid, but the test expected an error. Update the test expectation to nil and remove the unused "errors" import.