### PR TITLE
Add CI/CD workflows for automated build, test and release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - 'release-v*'
+
+jobs:
+  lint:
+    name: Lint
+    uses: ROCm/common-infra-operator/.github/workflows/go-lint.yaml@main
+    with:
+      go-version-file: go.mod
+      build-deps: "pkg-config libdrm-dev"
+      check-target: check
+
+  test:
+    name: Test
+    uses: ROCm/common-infra-operator/.github/workflows/go-test.yaml@main
+    with:
+      go-version-file: go.mod
+      build-deps: "pkg-config libdrm-dev"
+      test-target: test

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,64 @@
+name: Image
+
+on:
+  push:
+    branches:
+      - develop
+      - 'release-v*'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - develop
+      - main
+      - 'release-v*'
+
+# Serialize auto-tag + build per branch to prevent tag race conditions.
+# If two merges happen back-to-back, the second waits for the first to finish.
+concurrency:
+  group: image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Auto-tag and build/push on merge (push events only)
+  auto-tag:
+    name: Auto Tag
+    if: github.event_name == 'push' && github.repository == 'ROCm/k8s-gpu-dra-driver'
+    uses: ROCm/common-infra-operator/.github/workflows/auto-tag.yaml@main
+    with:
+      branch-type: ${{ startsWith(github.ref, 'refs/heads/release-v') && 'release' || 'develop' }}
+    permissions:
+      contents: write
+
+  build-push:
+    name: Build & Push
+    needs: auto-tag
+    if: github.event_name == 'push' && github.repository == 'ROCm/k8s-gpu-dra-driver'
+    uses: ROCm/common-infra-operator/.github/workflows/image-build-push.yaml@main
+    with:
+      image-registry: docker.io/amdpsdo
+      image-name: k8s-gpu-dra-driver
+      image-tag: ${{ needs.auto-tag.outputs.tag }}
+      push: true
+      env-registry: DRIVER_IMAGE_REGISTRY
+      env-name: DRIVER_IMAGE_NAME
+      env-tag: DRIVER_IMAGE_TAG
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  # Label-gated image build on PRs (build only, no push)
+  pr-build:
+    name: PR Build
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'ci-run') &&
+      github.repository == 'ROCm/k8s-gpu-dra-driver'
+    uses: ROCm/common-infra-operator/.github/workflows/image-build-push.yaml@main
+    with:
+      image-registry: docker.io/amdpsdo
+      image-name: k8s-gpu-dra-driver
+      image-tag: pr-${{ github.event.pull_request.number }}
+      push: false
+      env-registry: DRIVER_IMAGE_REGISTRY
+      env-name: DRIVER_IMAGE_NAME
+      env-tag: DRIVER_IMAGE_TAG

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # Matches clean semver tags (v1.0.0) but NOT build tags (v1.0.0-3)
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  image:
+    name: Release Image
+    if: github.repository == 'ROCm/k8s-gpu-dra-driver'
+    uses: ROCm/common-infra-operator/.github/workflows/image-build-push.yaml@main
+    with:
+      image-registry: docker.io/rocm
+      image-name: k8s-gpu-dra-driver
+      image-tag: ${{ github.ref_name }}
+      push: true
+      env-registry: DRIVER_IMAGE_REGISTRY
+      env-name: DRIVER_IMAGE_NAME
+      env-tag: DRIVER_IMAGE_TAG
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  helm-publish:
+    name: Publish Helm Chart
+    if: github.repository == 'ROCm/k8s-gpu-dra-driver'
+    uses: ROCm/common-infra-operator/.github/workflows/helm-gh-pages.yaml@main
+    with:
+      chart-dir: helm-charts-k8s
+      helm-repo-url: https://rocm.github.io/k8s-gpu-dra-driver
+      version: ${{ github.ref_name }}
+    permissions:
+      contents: write
+
+  release:
+    name: Draft Release
+    if: github.repository == 'ROCm/k8s-gpu-dra-driver'
+    needs: [image, helm-publish]
+    uses: ROCm/common-infra-operator/.github/workflows/draft-release.yaml@main
+    with:
+      version: ${{ github.ref_name }}
+      chart-dir: helm-charts-k8s
+    permissions:
+      contents: write


### PR DESCRIPTION
Add GitHub Actions caller workflows that use reusable workflows from pensando/common-infra-operator to automate the CI/CD pipeline:

- ci.yaml: lint and test on every PR to develop/main/release-v*
- image.yaml: auto-tag and build/push images on merge to develop and release branches; label-gated PR builds (ci-run label)
- release.yaml: on semver tag push, build and push release image to docker.io/rocm, publish Helm chart to gh-pages, create draft release