### PR TITLE
fix: handle GPUs without compute partition support (e.g. MI210)

### DIFF
--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -36,6 +36,7 @@ import (
 	"fmt"
 
 	"github.com/ROCm/k8s-gpu-dra-driver/pkg/amdgpu"
+	"github.com/ROCm/k8s-gpu-dra-driver/pkg/consts"
 	"k8s.io/dynamic-resource-allocation/deviceattribute"
 	klog "k8s.io/klog/v2"
 )
@@ -101,9 +102,9 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 		// Extract common topology information
 		simdUnits, computeUnits := extractTopologyInfo(gpuInfoMap)
 
-		if computePartitionType == "spx" || computePartitionType == "" {
+		if computePartitionType == consts.ComputePartitionSPX || computePartitionType == "" {
 			// This is a full AMD GPU (either explicitly "spx" or no partition support)
-			partitionProfile := "none"
+			partitionProfile := consts.DefaultPartitionProfile
 			if computePartitionType != "" && memoryPartitionType != "" {
 				partitionProfile = fmt.Sprintf("%s_%s", computePartitionType, memoryPartitionType)
 			}

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -101,8 +101,13 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 		// Extract common topology information
 		simdUnits, computeUnits := extractTopologyInfo(gpuInfoMap)
 
-		if computePartitionType == "spx" {
-			// This is a full AMD GPU
+		if computePartitionType == "spx" || computePartitionType == "" {
+			// This is a full AMD GPU (either explicitly "spx" or no partition support)
+			partitionProfile := "none"
+			if computePartitionType != "" && memoryPartitionType != "" {
+				partitionProfile = fmt.Sprintf("%s_%s", computePartitionType, memoryPartitionType)
+			}
+
 			amdGpuInfo := &AmdGpuInfo{
 				PCIAddress:       pciAddr,
 				CardIndex:        gpuInfoMap["card"].(int),
@@ -110,7 +115,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 				DeviceID:         gpuInfoMap["devID"].(string),
 				DriverVersion:    gpuInfoMap["driverVersion"].(string),
 				DriverSrcVersion: gpuInfoMap["driverSrcVersion"].(string),
-				PartitionProfile: fmt.Sprintf("%s_%s", computePartitionType, memoryPartitionType),
+				PartitionProfile: partitionProfile,
 				Family:           gpuInfoMap["family"].(string),
 				ProductName:      gpuInfoMap["productName"].(string),
 				pcieRootAttr:     pcieRootAttr,

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -33,3 +33,14 @@ limitations under the License.
 package consts
 
 const DriverName = "gpu.amd.com"
+
+// Compute partition modes
+const (
+	ComputePartitionSPX = "spx"
+	ComputePartitionDPX = "dpx"
+	ComputePartitionQPX = "qpx"
+	ComputePartitionCPX = "cpx"
+)
+
+// Default partition profile for non-partitioned GPUs
+const DefaultPartitionProfile = "spx_nps1"


### PR DESCRIPTION
GPUs that don't support compute partitions (like MI210) have no current_compute_partition sysfs file, resulting in an empty string. The existing code only handled "spx" (full GPU) and non-empty strings (partitions), causing non-partitioned GPUs to be silently skipped with a warning log and never published in ResourceSlice.

Treat empty computePartitionType the same as "spx" so these GPUs are correctly discovered and advertised as full GPUs.