### PR TITLE
fix: add OpenShift compatibility for DRA driver deployment

### DIFF
--- a/helm-charts-k8s/templates/kubeletplugin.yaml
+++ b/helm-charts-k8s/templates/kubeletplugin.yaml
@@ -71,7 +71,7 @@ spec:
         {{- end }}
         env:
         - name: CDI_ROOT
-          value: /var/run/cdi
+          value: {{ .Values.cdi.dynamicPath | quote }}
         - name: KUBELET_REGISTRAR_DIRECTORY_PATH
           value: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
         - name: KUBELET_PLUGINS_DIRECTORY_PATH
@@ -94,7 +94,7 @@ spec:
         - name: plugins
           mountPath: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
         - name: cdi
-          mountPath: /var/run/cdi
+          mountPath: {{ .Values.cdi.dynamicPath | quote }}
         - name: dev
           mountPath: /dev
         - name: sys
@@ -108,7 +108,7 @@ spec:
           path: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
       - name: cdi
         hostPath:
-          path: {{ .Values.cdi.dynamicPath }}
+          path: {{ .Values.cdi.dynamicPath | quote }}
       - name: dev
         hostPath:
           path: /dev

--- a/helm-charts-k8s/templates/scc.yaml
+++ b/helm-charts-k8s/templates/scc.yaml
@@ -1,0 +1,34 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k8s-gpu-dra-driver.fullname" . }}-scc
+  labels:
+    {{- include "k8s-gpu-dra-driver.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "k8s-gpu-dra-driver.fullname" . }}-scc
+  namespace: {{ include "k8s-gpu-dra-driver.namespace" . }}
+  labels:
+    {{- include "k8s-gpu-dra-driver.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8s-gpu-dra-driver.fullname" . }}-scc
+subjects:
+- kind: ServiceAccount
+  name: {{ include "k8s-gpu-dra-driver.serviceAccountName" . }}
+  namespace: {{ include "k8s-gpu-dra-driver.namespace" . }}
+{{- end }}


### PR DESCRIPTION
- Add SecurityContextConstraints (SCC) template that auto-detects OpenShift clusters and grants the driver service account the privileges needed for hostPath volumes and privileged containers
- Template CDI_ROOT env var and mount path from values.yaml instead of hardcoding /var/run/cdi, fixing a mismatch with the already- templated hostPath volume