### PR TITLE
fix: do not advertise partitionProfile for non-partitionable GPUs

### DIFF
--- a/cmd/gpu-kubeletplugin/deviceinfo.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo.go
@@ -93,12 +93,16 @@ func (d *AmdGpuInfo) GetDevice() resourceapi.Device {
 		"driverSrcVersion": {
 			StringValue: ptr.To(d.DriverSrcVersion),
 		},
-		"partitionProfile": {
-			StringValue: ptr.To(d.PartitionProfile),
-		},
 		"numaNode": {
 			IntValue: ptr.To(int64(d.NumaNode)),
 		},
+	}
+
+	// Only advertise partitionProfile if the GPU supports partitioning
+	if d.PartitionProfile != "" {
+		attributes["partitionProfile"] = resourceapi.DeviceAttribute{
+			StringValue: ptr.To(d.PartitionProfile),
+		}
 	}
 
 	// Add PCIe root attribute if available

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -104,7 +104,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 
 		if computePartitionType == consts.ComputePartitionSPX || computePartitionType == "" {
 			// This is a full AMD GPU (either explicitly "spx" or no partition support)
-			partitionProfile := consts.DefaultPartitionProfile
+			partitionProfile := ""
 			if computePartitionType != "" && memoryPartitionType != "" {
 				partitionProfile = fmt.Sprintf("%s_%s", computePartitionType, memoryPartitionType)
 			}


### PR DESCRIPTION
GPUs that lack current_compute_partition/current_memory_partition files under /sys/module/amdgpu/drivers/pci:amdgpu/ do not support partitioning. Previously these GPUs were incorrectly advertised with partitionProfile "spx_nps1". Now the partitionProfile attribute is omitted entirely when the GPU does not support partitioning.