### PR TITLE
helm: add deviceClass.create flag to control DeviceClass creation

### DIFF
--- a/helm-charts-k8s/templates/deviceclass.yaml
+++ b/helm-charts-k8s/templates/deviceclass.yaml
@@ -1,9 +1,12 @@
+{{- $draApi := include "k8s-gpu-dra-driver.draApiVersion" . -}}
+{{- if and .Values.deviceClass.create $draApi }}
 ---
-apiVersion: {{ include "k8s-gpu-dra-driver.draApiVersion" . }}
+apiVersion: {{ $draApi }}
 kind: DeviceClass
 metadata:
   name: gpu.amd.com
 spec:
   selectors:
-  - cel: 
+  - cel:
       expression: "device.driver == 'gpu.amd.com'"
+{{- end }}

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -16,6 +16,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+deviceClass:
+  # -- Create the gpu.amd.com DeviceClass resource. Set to false if deploying via gpu-operator.
+  create: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
When deploying the DRA driver standalone alongside gpu-operator, both charts create the same gpu.amd.com DeviceClass causing conflicts. Add a deviceClass.create flag (default true) to allow disabling DeviceClass creation via --set deviceClass.create=false.