### PR TITLE
fix: driver version fallback and multi-driver claim filter

### DIFF
--- a/cmd/gpu-kubeletplugin/deviceinfo.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo.go
@@ -65,10 +65,12 @@ func (d *AmdGpuInfo) CanonicalName() string {
 // GetDevice returns the DRA Device representation for a full AMD GPU
 func (d *AmdGpuInfo) GetDevice() resourceapi.Device {
 	attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-		"type":          {StringValue: ptr.To(AmdGpuDeviceType)},
-		"productName":   {StringValue: ptr.To(d.ProductName)},
-		"driverVersion": {VersionValue: ptr.To(d.DriverVersion)},
-		"numaNode":      {IntValue: ptr.To(int64(d.NumaNode))},
+		"type":        {StringValue: ptr.To(AmdGpuDeviceType)},
+		"productName": {StringValue: ptr.To(d.ProductName)},
+		"numaNode":    {IntValue: ptr.To(int64(d.NumaNode))},
+	}
+	if d.DriverVersion != "" {
+		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(d.DriverVersion)}
 	}
 	if d.DeviceID != "" {
 		attributes["deviceID"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.DeviceID)}
@@ -103,9 +105,11 @@ func (d *AmdPartitionInfo) GetDevice() resourceapi.Device {
 	attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 		"type":             {StringValue: ptr.To(AmdPartitionDeviceType)},
 		"productName":      {StringValue: ptr.To(d.Parent.ProductName)},
-		"driverVersion":    {VersionValue: ptr.To(d.Parent.DriverVersion)},
 		"partitionProfile": {StringValue: ptr.To(d.PartitionProfile)},
 		"numaNode":         {IntValue: ptr.To(int64(d.NumaNode))},
+	}
+	if d.Parent.DriverVersion != "" {
+		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(d.Parent.DriverVersion)}
 	}
 	if d.Parent.DeviceID != "" {
 		attributes["deviceID"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Parent.DeviceID)}

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -218,6 +218,10 @@ func (s *DeviceState) prepareDevices(claim *resourceapi.ResourceClaim) (Prepared
 	// each device allocation result based on their order of precedence.
 	configResultsMap := make(map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult)
 	for _, result := range claim.Status.Allocation.Devices.Results {
+		// Skip devices from other drivers in multi-driver claims.
+		if result.Driver != consts.DriverName {
+			continue
+		}
 		if _, exists := s.allocatable[result.Device]; !exists {
 			return nil, fmt.Errorf("requested GPU is not allocatable: %v", result.Device)
 		}

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -35,8 +35,8 @@ import (
 func GetDriverVersion() string {
 	matches, _ := filepath.Glob("/sys/class/drm/card*/device/driver/module/version")
 	if len(matches) == 0 {
-		glog.Warningf("No AMD GPU cards found for driver version reading")
-		return ""
+		glog.Warningf("No AMD GPU cards found for driver version reading, using fallback 0.0.0")
+		return "0.0.0"
 	}
 
 	for _, versionPath := range matches {
@@ -50,8 +50,10 @@ func GetDriverVersion() string {
 		}
 	}
 
-	glog.Warningf("Failed to read AMDGPU driver version from any card")
-	return ""
+	// In-kernel amdgpu module may not set a version string (empty /sys/module/amdgpu/version).
+	// Fall back to "0.0.0" so the ResourceSlice semver validation succeeds.
+	glog.Warningf("Failed to read AMDGPU driver version from any card, using fallback 0.0.0")
+	return "0.0.0"
 }
 
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -35,8 +35,8 @@ import (
 func GetDriverVersion() string {
 	matches, _ := filepath.Glob("/sys/class/drm/card*/device/driver/module/version")
 	if len(matches) == 0 {
-		glog.Warningf("No AMD GPU cards found for driver version reading, using fallback 0.0.0")
-		return "0.0.0"
+		glog.Warningf("No AMD GPU cards found for driver version reading; driverVersion attribute will be omitted")
+		return ""
 	}
 
 	for _, versionPath := range matches {
@@ -51,9 +51,10 @@ func GetDriverVersion() string {
 	}
 
 	// In-kernel amdgpu module may not set a version string (empty /sys/module/amdgpu/version).
-	// Fall back to "0.0.0" so the ResourceSlice semver validation succeeds.
-	glog.Warningf("Failed to read AMDGPU driver version from any card, using fallback 0.0.0")
-	return "0.0.0"
+	// Return empty so the caller omits the driverVersion attribute entirely rather than
+	// publishing a synthetic value; the ResourceSlice is still valid without it.
+	glog.Warningf("Failed to read AMDGPU driver version from any card; driverVersion attribute will be omitted")
+	return ""
 }
 
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address


### PR DESCRIPTION
## Summary

- **Driver version fallback**: `GetDriverVersion()` returns `"0.0.0"` when the in-kernel `amdgpu` module doesn't set a version string (empty `/sys/module/amdgpu/version`). Without this, ResourceSlice creation fails semver validation.
- **Multi-driver claim filter**: `prepareDevices()` skips allocation results where `result.Driver` doesn't match this driver's name. In multi-driver claims (e.g., GPU + CPU + NIC in the same ResourceClaim), the driver previously tried to prepare other drivers' devices and failed with `"requested GPU is not allocatable: cpudevnuma000"`.

## Test plan

- [ ] Deploy on a node where the amdgpu kernel module doesn't report a version string — verify ResourceSlice is created with `driverVersion: 0.0.0`
- [ ] Create a multi-driver ResourceClaim (GPU + CPU from different DRA drivers) — verify the GPU driver only prepares its own devices