### PR TITLE
feat: enable KEP-5304 device metadata

### DIFF
--- a/cmd/gpu-kubeletplugin/driver.go
+++ b/cmd/gpu-kubeletplugin/driver.go
@@ -45,6 +45,7 @@ import (
 	coreclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
+	drametadatav1alpha1 "k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1"
 	klog "k8s.io/klog/v2"
 
 	"github.com/ROCm/k8s-gpu-dra-driver/pkg/consts"
@@ -78,6 +79,8 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.DriverName(consts.DriverName),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
+		kubeletplugin.EnableDeviceMetadata(true),
+		kubeletplugin.MetadataVersions(drametadatav1alpha1.SchemeGroupVersion),
 	)
 	if err != nil {
 		return nil, err
@@ -146,12 +149,39 @@ func (d *driver) prepareResourceClaim(_ context.Context, claim *resourceapi.Reso
 	}
 	var prepared []kubeletplugin.Device
 	for _, preparedPB := range preparedPBs {
-		prepared = append(prepared, kubeletplugin.Device{
+		dev := kubeletplugin.Device{
 			Requests:     preparedPB.GetRequestNames(),
 			PoolName:     preparedPB.GetPoolName(),
 			DeviceName:   preparedPB.GetDeviceName(),
 			CDIDeviceIDs: preparedPB.GetCdiDeviceIds(),
-		})
+		}
+
+		// KEP-5304: expose GPU attributes to workloads via native metadata API
+		if allocDev, exists := d.state.allocatable[preparedPB.GetDeviceName()]; exists {
+			attrs := make(map[string]resourceapi.DeviceAttribute)
+			if allocDev.AmdGpu != nil {
+				pci := allocDev.AmdGpu.PCIAddress
+				product := allocDev.AmdGpu.ProductName
+				numa := int64(allocDev.AmdGpu.NumaNode)
+				attrs["resource.kubernetes.io/pciBusID"] = resourceapi.DeviceAttribute{StringValue: &pci}
+				attrs["productName"] = resourceapi.DeviceAttribute{StringValue: &product}
+				attrs["numaNode"] = resourceapi.DeviceAttribute{IntValue: &numa}
+			} else if allocDev.AmdPartition != nil {
+				pci := allocDev.AmdPartition.Parent.PCIAddress
+				product := allocDev.AmdPartition.Parent.ProductName
+				numa := int64(allocDev.AmdPartition.NumaNode)
+				attrs["resource.kubernetes.io/pciBusID"] = resourceapi.DeviceAttribute{StringValue: &pci}
+				attrs["productName"] = resourceapi.DeviceAttribute{StringValue: &product}
+				attrs["numaNode"] = resourceapi.DeviceAttribute{IntValue: &numa}
+			}
+			if len(attrs) > 0 {
+				dev.Metadata = &kubeletplugin.DeviceMetadata{
+					Attributes: attrs,
+				}
+			}
+		}
+
+		prepared = append(prepared, dev)
 	}
 
 	klog.Infof("Returning newly prepared devices for claim '%v': %v", claim.UID, prepared)

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -218,6 +218,10 @@ func (s *DeviceState) prepareDevices(claim *resourceapi.ResourceClaim) (Prepared
 	// each device allocation result based on their order of precedence.
 	configResultsMap := make(map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult)
 	for _, result := range claim.Status.Allocation.Devices.Results {
+		// Skip devices from other drivers in multi-driver claims.
+		if result.Driver != consts.DriverName {
+			continue
+		}
 		if _, exists := s.allocatable[result.Device]; !exists {
 			return nil, fmt.Errorf("requested GPU is not allocatable: %v", result.Device)
 		}

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -35,8 +35,8 @@ import (
 func GetDriverVersion() string {
 	matches, _ := filepath.Glob("/sys/class/drm/card*/device/driver/module/version")
 	if len(matches) == 0 {
-		glog.Warningf("No AMD GPU cards found for driver version reading")
-		return ""
+		glog.Warningf("No AMD GPU cards found for driver version reading, using fallback 0.0.0")
+		return "0.0.0"
 	}
 
 	for _, versionPath := range matches {
@@ -50,8 +50,10 @@ func GetDriverVersion() string {
 		}
 	}
 
-	glog.Warningf("Failed to read AMDGPU driver version from any card")
-	return ""
+	// In-kernel amdgpu module may not set a version string (empty /sys/module/amdgpu/version).
+	// Fall back to "0.0.0" so the ResourceSlice semver validation succeeds.
+	glog.Warningf("Failed to read AMDGPU driver version from any card, using fallback 0.0.0")
+	return "0.0.0"
 }
 
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address


### PR DESCRIPTION
## Summary

Enable the native KEP-5304 device metadata API (K8s 1.36+) so downstream consumers like KubeVirt virt-launcher can discover GPU device attributes at runtime.

When a GPU is prepared, the driver now publishes the following attributes in `PrepareResult` metadata:
- `resource.kubernetes.io/pciBusID` — PCI bus address for VFIO passthrough
- `numaNode` — NUMA node for guest topology placement
- `productName` — GPU product name

These are written by the kubelet as JSON files and mounted into the pod, where virt-launcher reads them to create `<hostdev>` entries and place devices on the correct guest NUMA node.

**Depends on:** #45 (driver version fallback + multi-driver claim filter)

## Test plan

- [ ] Deploy on a node with AMD GPUs — verify metadata JSON files appear at `/var/run/kubernetes.io/dra-device-attributes/resourceclaims/<claim>/<request>/`
- [ ] Verify `pciBusID`, `numaNode`, and `productName` are present for both full GPUs and partitions
- [ ] Verify KubeVirt virt-launcher can read the metadata to discover GPU PCI addresses