### PR TITLE
docs: add Quick Start section with Helm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocat
 - `scripts/` — project-level build and release helpers
 - `docs/` — documentation (installation, developer guides) (browse: https://github.com/ROCm/k8s-gpu-dra-driver/tree/main/docs)
 
+## Quick Start
+
+Install the DRA driver from the published Helm repository:
+
+```bash
+# Install Helm
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+
+# Add the Helm repository
+helm repo add rocm-k8s-gpu-dra-driver https://rocm.github.io/k8s-gpu-dra-driver
+helm repo update
+
+# Install the DRA driver
+helm install k8s-gpu-dra-driver rocm-k8s-gpu-dra-driver/k8s-gpu-dra-driver \
+  --namespace kube-amd-gpu \
+  --create-namespace
+```
+
 ## Getting started
 
 Read the Installation & Developer Guide for full, step-by-step installation and developer

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,26 @@ This document collects the common build, package, and demo commands used for
 working with the k8s-gpu-dra-driver repository. It pulls together the Makefile
 and demo script workflows so you can reproduce builds and demos locally.
 
+## Quick Start
+
+Install the DRA driver from the published Helm repository:
+
+```bash
+# Install Helm
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+
+# Add the Helm repository
+helm repo add rocm-k8s-gpu-dra-driver https://rocm.github.io/k8s-gpu-dra-driver
+helm repo update
+
+# Install the DRA driver
+helm install k8s-gpu-dra-driver rocm-k8s-gpu-dra-driver/k8s-gpu-dra-driver \
+  --namespace kube-amd-gpu \
+  --create-namespace
+```
+
 ## Prerequisites
 
 - GNU Make 3.81+


### PR DESCRIPTION
## Summary
- Add a **Quick Start** section to `README.md` (above "Getting started") with copy-paste commands to install Helm, add the `rocm-k8s-gpu-dra-driver` Helm repo, and install the driver into the `kube-amd-gpu` namespace.
- Mirror the same Quick Start section into `docs/installation.md` (above "Prerequisites") so users landing on the install guide get the same fast path.

## Test plan
- [x] Markdown renders correctly on GitHub
- [x] Commands match the published Helm repo at https://rocm.github.io/k8s-gpu-dra-driver