### PR TITLE
Remove alpha status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This repository implements an AMD GPU resource driver for Kubernetes' Dynamic
 Resource Allocation (DRA) feature. The driver exposes device classes and
 implements allocation and lifecycle behavior for GPU resources on nodes.
 
-> Status: Experimental (alpha). Not recommended for production environments yet.
-
 ## DRA Concepts
 
 - Device class: a logical grouping of devices exposed by the driver (for


### PR DESCRIPTION
## Summary
Backport of the alpha-status removal (commit b91449cd from `main`) to `release-v1.0.0`, so the release branch's README reflects the v1.0.0 "first official release" status.

## Test plan
- [x] `README.md` no longer states "Experimental (alpha) — Not recommended for production".
- [x] No other content changed.