### PR TITLE
sync: bring main-only commits back into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This repository implements an AMD GPU resource driver for Kubernetes' Dynamic
 Resource Allocation (DRA) feature. The driver exposes device classes and
 implements allocation and lifecycle behavior for GPU resources on nodes.
 
-> Status: Experimental (alpha). Not recommended for production environments yet.
-
 ## DRA Concepts
 
 - Device class: a logical grouping of devices exposed by the driver (for

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocat
 - `scripts/` — project-level build and release helpers
 - `docs/` — documentation (installation, developer guides) (browse: https://github.com/ROCm/k8s-gpu-dra-driver/tree/main/docs)
 
+## Quick Start
+
+Install the DRA driver from the published Helm repository:
+
+```bash
+# Install Helm
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+
+# Add the Helm repository
+helm repo add rocm-k8s-gpu-dra-driver https://rocm.github.io/k8s-gpu-dra-driver
+helm repo update
+
+# Install the DRA driver
+helm install k8s-gpu-dra-driver rocm-k8s-gpu-dra-driver/k8s-gpu-dra-driver \
+  --namespace kube-amd-gpu \
+  --create-namespace
+```
+
 ## Getting started
 
 Read the Installation & Developer Guide for full, step-by-step installation and developer

--- a/cmd/gpu-kubeletplugin/deviceinfo.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo.go
@@ -65,10 +65,12 @@ func (d *AmdGpuInfo) CanonicalName() string {
 // GetDevice returns the DRA Device representation for a full AMD GPU
 func (d *AmdGpuInfo) GetDevice() resourceapi.Device {
 	attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-		"type":          {StringValue: ptr.To(AmdGpuDeviceType)},
-		"productName":   {StringValue: ptr.To(d.ProductName)},
-		"driverVersion": {VersionValue: ptr.To(d.DriverVersion)},
-		"numaNode":      {IntValue: ptr.To(int64(d.NumaNode))},
+		"type":        {StringValue: ptr.To(AmdGpuDeviceType)},
+		"productName": {StringValue: ptr.To(d.ProductName)},
+		"numaNode":    {IntValue: ptr.To(int64(d.NumaNode))},
+	}
+	if d.DriverVersion != "" {
+		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(d.DriverVersion)}
 	}
 	if d.DeviceID != "" {
 		attributes["deviceID"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.DeviceID)}
@@ -103,9 +105,11 @@ func (d *AmdPartitionInfo) GetDevice() resourceapi.Device {
 	attributes := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 		"type":             {StringValue: ptr.To(AmdPartitionDeviceType)},
 		"productName":      {StringValue: ptr.To(d.Parent.ProductName)},
-		"driverVersion":    {VersionValue: ptr.To(d.Parent.DriverVersion)},
 		"partitionProfile": {StringValue: ptr.To(d.PartitionProfile)},
 		"numaNode":         {IntValue: ptr.To(int64(d.NumaNode))},
+	}
+	if d.Parent.DriverVersion != "" {
+		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(d.Parent.DriverVersion)}
 	}
 	if d.Parent.DeviceID != "" {
 		attributes["deviceID"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Parent.DeviceID)}

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -218,6 +218,10 @@ func (s *DeviceState) prepareDevices(claim *resourceapi.ResourceClaim) (Prepared
 	// each device allocation result based on their order of precedence.
 	configResultsMap := make(map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult)
 	for _, result := range claim.Status.Allocation.Devices.Results {
+		// Skip devices from other drivers in multi-driver claims.
+		if result.Driver != consts.DriverName {
+			continue
+		}
 		if _, exists := s.allocatable[result.Device]; !exists {
 			return nil, fmt.Errorf("requested GPU is not allocatable: %v", result.Device)
 		}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,26 @@ This document collects the common build, package, and demo commands used for
 working with the k8s-gpu-dra-driver repository. It pulls together the Makefile
 and demo script workflows so you can reproduce builds and demos locally.
 
+## Quick Start
+
+Install the DRA driver from the published Helm repository:
+
+```bash
+# Install Helm
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+
+# Add the Helm repository
+helm repo add rocm-k8s-gpu-dra-driver https://rocm.github.io/k8s-gpu-dra-driver
+helm repo update
+
+# Install the DRA driver
+helm install k8s-gpu-dra-driver rocm-k8s-gpu-dra-driver/k8s-gpu-dra-driver \
+  --namespace kube-amd-gpu \
+  --create-namespace
+```
+
 ## Prerequisites
 
 - GNU Make 3.81+

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -35,7 +35,7 @@ import (
 func GetDriverVersion() string {
 	matches, _ := filepath.Glob("/sys/class/drm/card*/device/driver/module/version")
 	if len(matches) == 0 {
-		glog.Warningf("No AMD GPU cards found for driver version reading")
+		glog.Warningf("No AMD GPU cards found for driver version reading; driverVersion attribute will be omitted")
 		return ""
 	}
 
@@ -50,7 +50,10 @@ func GetDriverVersion() string {
 		}
 	}
 
-	glog.Warningf("Failed to read AMDGPU driver version from any card")
+	// In-kernel amdgpu module may not set a version string (empty /sys/module/amdgpu/version).
+	// Return empty so the caller omits the driverVersion attribute entirely rather than
+	// publishing a synthetic value; the ResourceSlice is still valid without it.
+	glog.Warningf("Failed to read AMDGPU driver version from any card; driverVersion attribute will be omitted")
 	return ""
 }
 


### PR DESCRIPTION
## Summary
Restores the develop → main contract by bringing the commits that landed directly on `main` back into `develop`. Done as cherry-picks (not a merge) to keep history clean and avoid pulling in the noisy back-merge merge commits.

Commits (original authors preserved):
- `b91449c` Remove alpha status from README.md
- `ebaeee5` docs: add Quick Start section with Helm install instructions
- `4c9e73b` fix: driver version fallback and multi-driver claim filter (#45)

## Notes
- The 5 `Merge pull request from ROCm/develop` commits on main are back-merges with no new content, so they are intentionally excluded.
- main's older `helm-charts-k8s` changes are intentionally NOT brought over — develop's #44 (deviceClass.create flag) supersedes them.
- Net file diff vs develop is exactly the 3 commits above.

## Test plan
- [ ] CI passes