### PR TITLE
ci: enforce develop->main contract and mirror build flow for main

### DIFF
--- a/.github/workflows/enforce-main-source.yaml
+++ b/.github/workflows/enforce-main-source.yaml
@@ -1,0 +1,27 @@
+name: Enforce main source branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    name: PR into main must come from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify head branch is develop from this repo
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::PRs into 'main' must originate from the '$BASE_REPO' repository, not a fork ($HEAD_REPO)."
+            exit 1
+          fi
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::PRs into 'main' must come from the 'develop' branch. This PR is from '$HEAD_REF'."
+            exit 1
+          fi
+          echo "OK: PR into 'main' is from '$BASE_REPO:develop'."

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - main
       - 'release-v*'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
@@ -25,7 +26,7 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'ROCm/k8s-gpu-dra-driver'
     uses: ROCm/common-infra-operator/.github/workflows/auto-tag.yaml@main
     with:
-      branch-type: ${{ startsWith(github.ref, 'refs/heads/release-v') && 'release' || 'develop' }}
+      branch-type: ${{ startsWith(github.ref, 'refs/heads/release-v') && 'release' || github.ref == 'refs/heads/main' && 'main' || 'develop' }}
     permissions:
       contents: write
 
@@ -83,6 +84,10 @@ jobs:
             # develop-4 -> 0.0.0-develop.4
             BUILD_NUM="${TAG#develop-}"
             CHART_VERSION="0.0.0-develop.${BUILD_NUM}"
+          elif [ "$BRANCH" = "main" ]; then
+            # main-4 -> 0.0.0-main.4
+            BUILD_NUM="${TAG#main-}"
+            CHART_VERSION="0.0.0-main.${BUILD_NUM}"
           else
             # v1.0.0-3 -> 1.0.0-3
             CHART_VERSION="${TAG#v}"


### PR DESCRIPTION
## Summary
Two CI changes that harden the develop -> main contract:

1. **Enforce PR source into main** (`enforce-main-source.yaml`): fails any PR targeting `main` that does not originate from the `develop` branch of this repo (also rejects fork PRs). Intended to be marked as a **required status check** on `main` so the contract cannot be bypassed.
2. **Mirror develop's build/tag/push flow for main** (`image.yaml`): on push to `main`, auto-tag as `main-N` and run the full build, image push, and Helm chart publish, mirroring the develop flow so main merges produce testable images. Chart version derives as `0.0.0-main.N`.

## Dependencies
- Requires the `main` branch-type added to `ROCm/common-infra-operator`'s `auto-tag.yaml` (merged in common-infra-operator#8).

## Follow-up (manual, needs repo admin)
- Add **"PR into main must come from develop"** as a required status check in `main` branch protection so the guard actually blocks merges.

## Test plan
- [ ] CI passes
- [ ] After merge to main, confirm a `main-N` tag + image + chart are produced
- [ ] Confirm a PR into main from a non-develop branch fails the guard check