### PR TITLE
feat: enable KEP-5304 device metadata

### DIFF
--- a/cmd/gpu-kubeletplugin/driver.go
+++ b/cmd/gpu-kubeletplugin/driver.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreclientset "k8s.io/client-go/kubernetes"
+	drametadatav1alpha1 "k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	klog "k8s.io/klog/v2"
@@ -78,6 +79,8 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.DriverName(consts.DriverName),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
+		kubeletplugin.EnableDeviceMetadata(true),
+		kubeletplugin.MetadataVersions(drametadatav1alpha1.SchemeGroupVersion),
 	)
 	if err != nil {
 		return nil, err
@@ -146,12 +149,39 @@ func (d *driver) prepareResourceClaim(_ context.Context, claim *resourceapi.Reso
 	}
 	var prepared []kubeletplugin.Device
 	for _, preparedPB := range preparedPBs {
-		prepared = append(prepared, kubeletplugin.Device{
+		dev := kubeletplugin.Device{
 			Requests:     preparedPB.GetRequestNames(),
 			PoolName:     preparedPB.GetPoolName(),
 			DeviceName:   preparedPB.GetDeviceName(),
 			CDIDeviceIDs: preparedPB.GetCdiDeviceIds(),
-		})
+		}
+
+		// KEP-5304: expose GPU attributes to workloads via native metadata API
+		if allocDev, exists := d.state.allocatable[preparedPB.GetDeviceName()]; exists {
+			attrs := make(map[string]resourceapi.DeviceAttribute)
+			if allocDev.AmdGpu != nil {
+				pci := allocDev.AmdGpu.PCIAddress
+				product := allocDev.AmdGpu.ProductName
+				numa := int64(allocDev.AmdGpu.NumaNode)
+				attrs["resource.kubernetes.io/pciBusID"] = resourceapi.DeviceAttribute{StringValue: &pci}
+				attrs["productName"] = resourceapi.DeviceAttribute{StringValue: &product}
+				attrs["numaNode"] = resourceapi.DeviceAttribute{IntValue: &numa}
+			} else if allocDev.AmdPartition != nil {
+				pci := allocDev.AmdPartition.Parent.PCIAddress
+				product := allocDev.AmdPartition.Parent.ProductName
+				numa := int64(allocDev.AmdPartition.NumaNode)
+				attrs["resource.kubernetes.io/pciBusID"] = resourceapi.DeviceAttribute{StringValue: &pci}
+				attrs["productName"] = resourceapi.DeviceAttribute{StringValue: &product}
+				attrs["numaNode"] = resourceapi.DeviceAttribute{IntValue: &numa}
+			}
+			if len(attrs) > 0 {
+				dev.Metadata = &kubeletplugin.DeviceMetadata{
+					Attributes: attrs,
+				}
+			}
+		}
+
+		prepared = append(prepared, dev)
 	}
 
 	klog.Infof("Returning newly prepared devices for claim '%v': %v", claim.UID, prepared)


### PR DESCRIPTION
## Summary

- Enable the DRA native device metadata API (KEP-5304) so workloads (e.g. KubeVirt virt-launcher) can discover GPU PCI addresses and NUMA nodes.
- Publishes `resource.kubernetes.io/pciBusID`, `productName`, and `numaNode` for both full GPUs and partitions.

## Notes

- Cherry-picked from #48 (authored by John Hull), retargeted to `develop` per the repo rule that PRs into `main` originate from `develop`.
- Applied `gofmt -s` to fix import ordering so `make check` (`assert-fmt`) passes CI.

## Test plan

- [ ] Deploy on a Kubernetes 1.33+ cluster with KEP-5304 feature gate enabled
- [ ] Verify `resource.kubernetes.io/pciBusID`, `productName`, `numaNode` for full GPUs and partitions
- [ ] Confirm no regression in standard GPU allocation