### PR TITLE
fix: normalize AMDGPU driver version to valid semver for ResourceSlice

### DIFF
--- a/cmd/gpu-kubeletplugin/deviceinfo.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/dynamic-resource-allocation/deviceattribute"
 	"k8s.io/utils/ptr"
+
+	"github.com/ROCm/k8s-gpu-dra-driver/pkg/amdgpu"
 )
 
 // AmdGpuInfo represents a full AMD GPU device
@@ -70,7 +72,8 @@ func (d *AmdGpuInfo) GetDevice() resourceapi.Device {
 		"numaNode":    {IntValue: ptr.To(int64(d.NumaNode))},
 	}
 	if d.DriverVersion != "" {
-		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(d.DriverVersion)}
+		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(amdgpu.SemverDriverVersion(d.DriverVersion))}
+		attributes["driverVersionFull"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.DriverVersion)}
 	}
 	if d.DeviceID != "" {
 		attributes["deviceID"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.DeviceID)}
@@ -109,7 +112,8 @@ func (d *AmdPartitionInfo) GetDevice() resourceapi.Device {
 		"numaNode":         {IntValue: ptr.To(int64(d.NumaNode))},
 	}
 	if d.Parent.DriverVersion != "" {
-		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(d.Parent.DriverVersion)}
+		attributes["driverVersion"] = resourceapi.DeviceAttribute{VersionValue: ptr.To(amdgpu.SemverDriverVersion(d.Parent.DriverVersion))}
+		attributes["driverVersionFull"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Parent.DriverVersion)}
 	}
 	if d.Parent.DeviceID != "" {
 		attributes["deviceID"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Parent.DeviceID)}

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -46,7 +46,7 @@ func GetDriverVersion() string {
 		}
 		driverVersion := strings.TrimSpace(string(b))
 		if driverVersion != "" {
-			return normalizeDriverVersion(driverVersion)
+			return driverVersion
 		}
 	}
 
@@ -57,12 +57,13 @@ func GetDriverVersion() string {
 	return ""
 }
 
-// normalizeDriverVersion trims the AMDGPU version to MAJOR.MINOR.PATCH. The
+// SemverDriverVersion trims the AMDGPU version to MAJOR.MINOR.PATCH. The
 // out-of-tree amdgpu module reports a 4-component string (e.g. "6.19.14.31400000"
 // where the trailing field is a build number), which the DRA ResourceSlice
 // VersionValue rejects for not being valid semver 2.0.0. Keep the first three
-// numeric components and drop the build metadata.
-func normalizeDriverVersion(version string) string {
+// numeric components and drop the build metadata; the full raw string is
+// published separately as a string attribute.
+func SemverDriverVersion(version string) string {
 	parts := strings.Split(version, ".")
 	if len(parts) <= 3 {
 		return version

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -46,7 +46,7 @@ func GetDriverVersion() string {
 		}
 		driverVersion := strings.TrimSpace(string(b))
 		if driverVersion != "" {
-			return driverVersion
+			return normalizeDriverVersion(driverVersion)
 		}
 	}
 
@@ -55,6 +55,19 @@ func GetDriverVersion() string {
 	// publishing a synthetic value; the ResourceSlice is still valid without it.
 	glog.Warningf("Failed to read AMDGPU driver version from any card; driverVersion attribute will be omitted")
 	return ""
+}
+
+// normalizeDriverVersion trims the AMDGPU version to MAJOR.MINOR.PATCH. The
+// out-of-tree amdgpu module reports a 4-component string (e.g. "6.19.14.31400000"
+// where the trailing field is a build number), which the DRA ResourceSlice
+// VersionValue rejects for not being valid semver 2.0.0. Keep the first three
+// numeric components and drop the build metadata.
+func normalizeDriverVersion(version string) string {
+	parts := strings.Split(version, ".")
+	if len(parts) <= 3 {
+		return version
+	}
+	return strings.Join(parts[:3], ".")
 }
 
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address

--- a/pkg/amdgpu/amdgpu_test.go
+++ b/pkg/amdgpu/amdgpu_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amdgpu
+
+import "testing"
+
+func TestNormalizeDriverVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"four components drops build metadata", "6.19.14.31400000", "6.19.14"},
+		{"three components unchanged", "6.19.14", "6.19.14"},
+		{"two components unchanged", "6.19", "6.19"},
+		{"single component unchanged", "6", "6"},
+		{"more than four components keeps first three", "6.19.14.3.1", "6.19.14"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeDriverVersion(tt.in); got != tt.want {
+				t.Errorf("normalizeDriverVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/amdgpu/amdgpu_test.go
+++ b/pkg/amdgpu/amdgpu_test.go
@@ -18,7 +18,7 @@ package amdgpu
 
 import "testing"
 
-func TestNormalizeDriverVersion(t *testing.T) {
+func TestSemverDriverVersion(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
@@ -32,8 +32,8 @@ func TestNormalizeDriverVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeDriverVersion(tt.in); got != tt.want {
-				t.Errorf("normalizeDriverVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			if got := SemverDriverVersion(tt.in); got != tt.want {
+				t.Errorf("SemverDriverVersion(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- The out-of-tree amdgpu module reports a 4-component driver version string (e.g. `6.19.14.31400000`, where the trailing field is a build number). The DRA `ResourceSlice` `driverVersion` attribute uses `VersionValue`, which the API server validates as semver 2.0.0.
- Every ResourceSlice create was rejected with `must be a string compatible with semver.org spec 2.0.0`, so **no ResourceSlices were published** and all DRA workload tests failed with `No ResourceSlices found`.

## Fix
Publish two attributes so nothing is lost:
- `driverVersion` (`VersionValue`) — normalized to `MAJOR.MINOR.PATCH` so it is valid semver and workloads can range-match (e.g. `driverVersion.isGreaterThan(semver("6.19.0"))`).
- `driverVersionFull` (`StringValue`) — the complete raw string including the build number, for users who need the exact build (requested capability).

The raw version flows through `AmdGpuInfo.DriverVersion` unchanged; normalization is applied only at the publish site via `amdgpu.SemverDriverVersion`.

## Why it only affects our driver
The stock in-kernel amdgpu module leaves `/sys/.../module/version` empty (the attribute is then omitted). Only the out-of-tree driver we build and install via KMM populates the 4-component string, so this surfaced on CI nodes running our packaged driver.

## Test plan
- [x] `go test ./pkg/amdgpu/` — `TestSemverDriverVersion` covers 4-part, 3-part, shorter, and 5-part inputs
- [x] `go build ./...`
- [ ] CI DRA suite publishes ResourceSlices and DRA workload tests pass