### PR TITLE
feat: add feature-gate mechanism (#64)

### DIFF
--- a/cmd/gpu-kubeletplugin/main.go
+++ b/cmd/gpu-kubeletplugin/main.go
@@ -48,7 +48,8 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"github.com/ROCm/k8s-gpu-dra-driver/pkg/consts"
-	"github.com/ROCm/k8s-gpu-dra-driver/pkg/flags"
+	"github.com/ROCm/k8s-gpu-dra-driver/pkg/featuregates"
+	cflags "github.com/ROCm/k8s-gpu-dra-driver/pkg/flags"
 )
 
 const (
@@ -56,8 +57,8 @@ const (
 )
 
 type Flags struct {
-	kubeClientConfig flags.KubeClientConfig
-	loggingConfig    *flags.LoggingConfig
+	kubeClientConfig cflags.KubeClientConfig
+	loggingConfig    *cflags.LoggingConfig
 
 	nodeName                      string
 	cdiRoot                       string
@@ -85,7 +86,7 @@ func main() {
 
 func newApp() *cli.App {
 	flags := &Flags{
-		loggingConfig: flags.NewLoggingConfig(),
+		loggingConfig: cflags.NewLoggingConfig(),
 	}
 	cliFlags := []cli.Flag{
 		&cli.StringFlag{
@@ -126,6 +127,7 @@ func newApp() *cli.App {
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)
 	cliFlags = append(cliFlags, flags.loggingConfig.Flags()...)
+	cliFlags = append(cliFlags, cflags.FeatureGateFlags(flags.loggingConfig)...)
 
 	app := &cli.App{
 		Name:            "gpu-amd-kubeletplugin",
@@ -137,9 +139,16 @@ func newApp() *cli.App {
 			if c.Args().Len() > 0 {
 				return fmt.Errorf("arguments not supported: %v", c.Args().Slice())
 			}
-			return flags.loggingConfig.Apply()
+			if err := flags.loggingConfig.Apply(); err != nil {
+				return err
+			}
+			if err := featuregates.ValidateFeatureGates(); err != nil {
+				return fmt.Errorf("feature gate validation failed: %w", err)
+			}
+			return nil
 		},
 		Action: func(c *cli.Context) error {
+			klog.Infof("Feature gates: %s", cflags.FeatureGatesString(flags.loggingConfig))
 			ctx := c.Context
 			clientSets, err := flags.kubeClientConfig.NewClientSets()
 			if err != nil {

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -34,4 +34,20 @@ allocation requests.
 | `--logging-format` | string | `text` | `LOGGING_FORMAT` | Log output format. Permitted formats: `text`, `json`. |
 | `--log-flush-frequency` | duration | `5s` | `LOG_FLUSH_FREQUENCY` | Maximum number of seconds between log flushes. |
 | `--vmodule` | string | *(empty)* | `VMODULE` | Comma-separated list of `pattern=N` settings for file-filtered logging (text format only). |
-| `--feature-gates` | string | `ContextualLogging=true` | `FEATURE_GATES` | A set of `key=value` pairs describing feature gates for alpha/experimental logging features. |
+
+## Feature Gates
+
+The driver supports Kubernetes-style feature gates via the `--feature-gates`
+flag (or the `FEATURE_GATES` environment variable), a comma-separated list of
+`Name=true|false` pairs. The single flag controls both the driver's own gates
+and the standard Kubernetes logging gates (e.g. `ContextualLogging`). Unknown
+names cause the plugin to fail at startup.
+
+Gates are set via Helm:
+
+```yaml
+featureGates:
+  ExampleFeature: true
+```
+
+or `helm ... --set featureGates.ExampleFeature=true`.

--- a/helm-charts-k8s/templates/kubeletplugin.yaml
+++ b/helm-charts-k8s/templates/kubeletplugin.yaml
@@ -88,6 +88,12 @@ spec:
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}
         {{- end }}
+        {{- if .Values.featureGates }}
+        - name: FEATURE_GATES
+          value: "{{- $pairs := list -}}
+            {{- range $k, $v := .Values.featureGates }}{{ $pairs = append $pairs (printf "%s=%v" $k $v) }}{{- end -}}
+            {{- join "," $pairs -}}"
+        {{- end }}
         volumeMounts:
         - name: plugins-registry
           mountPath: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -82,3 +82,11 @@ webhook:
 
 cdi:
   dynamicPath: /var/run/cdi
+
+# Feature gates for alpha/experimental features (key: true/false), rendered into
+# the FEATURE_GATES environment variable. Standard Kubernetes logging gates (e.g.
+# ContextualLogging) are also accepted here.
+# Example:
+#   featureGates:
+#     ExampleFeature: true
+featureGates: {}

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package featuregates
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
+)
+
+// emulationVersion pins the driver registry to the driver's own version line.
+// Because this registry contains ONLY driver-owned gates (never upstream gates
+// registered at Kubernetes versions), this value never causes a gate to fall
+// through to PreAlpha, so there is no startup-panic risk.
+var emulationVersion = version.MajorMinor(0, 1)
+
+// ExampleFeature is a template for adding a driver feature gate. Define a
+// featuregate.Feature constant for each gate:
+//
+//	const ExampleFeature featuregate.Feature = "ExampleFeature"
+
+// defaultFeatureGates registers the driver's feature gates. Add each gate here,
+// defaulting off at Alpha on the driver's version line:
+//
+//	var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+//		ExampleFeature: {
+//			{Default: false, PreRelease: featuregate.Alpha, Version: version.MajorMinor(0, 1)},
+//		},
+//	}
+var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{}
+
+var (
+	once         sync.Once
+	featureGates featuregate.MutableVersionedFeatureGate
+)
+
+// FeatureGates returns the process-wide driver feature-gate registry.
+func FeatureGates() featuregate.MutableVersionedFeatureGate {
+	once.Do(func() {
+		fg := featuregate.NewVersionedFeatureGate(emulationVersion)
+		if err := fg.AddVersioned(defaultFeatureGates); err != nil {
+			panic(err) // programmer error: malformed static registry
+		}
+		featureGates = fg
+	})
+	return featureGates
+}
+
+// Enabled reports whether the named driver feature gate is enabled.
+func Enabled(f featuregate.Feature) bool { return FeatureGates().Enabled(f) }
+
+// KnownFeatures returns help strings for all known driver gates.
+func KnownFeatures() []string { return FeatureGates().KnownFeatures() }
+
+// ToMap returns the current enablement state of all driver gates.
+func ToMap() map[string]bool {
+	fg := FeatureGates()
+	out := map[string]bool{}
+	for f := range fg.GetAll() {
+		out[string(f)] = fg.Enabled(f)
+	}
+	return out
+}
+
+// ValidateFeatureGates checks cross-gate constraints. No constraints exist yet;
+// this is a stub kept in place so callers and wiring are ready for future gates.
+func ValidateFeatureGates() error { return nil }

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package featuregates
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
+)
+
+// exampleFeature is a synthetic gate used to exercise the registry machinery
+// against a fresh registry, since the shipped registry is empty.
+const exampleFeature featuregate.Feature = "ExampleFeature"
+
+// newTestGates builds a standalone registry (not the singleton) seeded with a
+// single Alpha exampleFeature, so tests can verify set/enable behavior.
+func newTestGates(t *testing.T) featuregate.MutableVersionedFeatureGate {
+	t.Helper()
+	fg := featuregate.NewVersionedFeatureGate(emulationVersion)
+	if err := fg.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		exampleFeature: {{Default: false, PreRelease: featuregate.Alpha, Version: version.MajorMinor(0, 1)}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return fg
+}
+
+func TestDriverRegistryShipsNoGates(t *testing.T) {
+	if len(defaultFeatureGates) != 0 {
+		t.Fatalf("driver ships the feature-gate machinery only; defaultFeatureGates should be empty, got %v", defaultFeatureGates)
+	}
+}
+
+func TestFeatureGatesSingletonNonNil(t *testing.T) {
+	if FeatureGates() == nil {
+		t.Fatalf("FeatureGates() should return a non-nil registry even with no driver gates")
+	}
+}
+
+func TestValidateFeatureGatesNoop(t *testing.T) {
+	if err := ValidateFeatureGates(); err != nil {
+		t.Fatalf("ValidateFeatureGates() should return nil, got %v", err)
+	}
+}
+
+func TestSetEnablesGate(t *testing.T) {
+	fg := newTestGates(t)
+	if fg.Enabled(exampleFeature) {
+		t.Fatalf("exampleFeature should default to false")
+	}
+	if err := fg.Set("ExampleFeature=true"); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+	if !fg.Enabled(exampleFeature) {
+		t.Fatalf("exampleFeature should be enabled after Set")
+	}
+}
+
+func TestSetUnknownGateFails(t *testing.T) {
+	fg := newTestGates(t)
+	if err := fg.Set("Bogus=true"); err == nil {
+		t.Fatalf("Set should reject unknown gate")
+	}
+}
+
+// TestSetGateNotYetAvailableFails verifies that a gate whose introduction
+// version is newer than the registry's emulation version resolves to PreAlpha
+// and cannot be set. This is the version-boundary behavior our driver-only
+// registry relies on.
+func TestSetGateNotYetAvailableFails(t *testing.T) {
+	fg := featuregate.NewVersionedFeatureGate(emulationVersion)
+	const future featuregate.Feature = "FutureFeature"
+	if err := fg.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		future: {{Default: false, PreRelease: featuregate.Alpha, Version: version.MajorMinor(9, 9)}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fg.Set("FutureFeature=true"); err == nil {
+		t.Fatalf("setting a gate newer than the emulation version should fail")
+	}
+}
+
+// TestSetGraduatedGaGateIsLocked verifies that a gate graduated to GA is locked
+// to its default: flipping it to the non-default value fails, while setting it
+// to its default value succeeds.
+func TestSetGraduatedGaGateIsLocked(t *testing.T) {
+	fg := featuregate.NewVersionedFeatureGate(emulationVersion)
+	const graduated featuregate.Feature = "GraduatedFeature"
+	if err := fg.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		graduated: {{Default: true, PreRelease: featuregate.GA, LockToDefault: true, Version: version.MajorMinor(0, 1)}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fg.Set("GraduatedFeature=false"); err == nil {
+		t.Fatalf("flipping a GA locked-to-default gate to the non-default value should fail")
+	}
+	if err := fg.Set("GraduatedFeature=true"); err != nil {
+		t.Fatalf("setting a GA gate to its default value should succeed, got %v", err)
+	}
+}

--- a/pkg/flags/featuregates.go
+++ b/pkg/flags/featuregates.go
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	cli "github.com/urfave/cli/v2"
+
+	"k8s.io/component-base/featuregate"
+
+	"github.com/ROCm/k8s-gpu-dra-driver/pkg/featuregates"
+)
+
+// gateMux implements pflag.Value, fronting multiple component-base registries
+// behind a single --feature-gates flag. Each key=value is routed to the registry
+// that owns the key. Unknown keys fail fast, matching component-base behavior.
+type gateMux struct {
+	registries []featuregate.MutableVersionedFeatureGate
+}
+
+// owner returns the registry that knows key, or nil if none do. GetAll includes
+// GA/Deprecated gates (KnownFeatures hides them), so routing stays correct across
+// maturity stages. The AllAlpha/AllBeta meta-gates exist in every registry and
+// are rejected in Set before reaching here, so ambiguous ownership never arises.
+func (m *gateMux) owner(key string) featuregate.MutableVersionedFeatureGate {
+	for _, r := range m.registries {
+		if _, ok := r.GetAll()[featuregate.Feature(key)]; ok {
+			return r
+		}
+	}
+	return nil
+}
+
+func (m *gateMux) Set(value string) error {
+	perRegistry := map[featuregate.MutableVersionedFeatureGate]map[string]bool{}
+	for _, pair := range strings.Split(value, ",") {
+		if strings.TrimSpace(pair) == "" {
+			continue
+		}
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("missing bool value for feature gate %q", strings.TrimSpace(kv[0]))
+		}
+		key := strings.TrimSpace(kv[0])
+		// The AllAlpha/AllBeta meta-gates exist in every registry, so they cannot
+		// be routed to a single owner unambiguously and would silently toggle only
+		// the first registry's gates. Reject them rather than mislead.
+		if key == "AllAlpha" || key == "AllBeta" {
+			return fmt.Errorf("feature gate %s is not supported through this flag; set individual gates by name", key)
+		}
+		b, err := strconv.ParseBool(strings.TrimSpace(kv[1]))
+		if err != nil {
+			return fmt.Errorf("invalid value for feature gate %s: %w", key, err)
+		}
+		owner := m.owner(key)
+		if owner == nil {
+			return fmt.Errorf("unrecognized feature gate: %s", key)
+		}
+		if perRegistry[owner] == nil {
+			perRegistry[owner] = map[string]bool{}
+		}
+		perRegistry[owner][key] = b
+	}
+	// Validate every registry's batch against a deep copy before mutating any of
+	// them, so a failure in one registry does not leave another partially applied.
+	for reg, keys := range perRegistry {
+		if err := reg.DeepCopy().SetFromMap(keys); err != nil {
+			return err
+		}
+	}
+	for reg, keys := range perRegistry {
+		if err := reg.SetFromMap(keys); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *gateMux) String() string {
+	parts := make([]string, 0, len(m.registries))
+	for _, r := range m.registries {
+		// String() is defined on the concrete *featureGate, not on the
+		// MutableVersionedFeatureGate interface, so assert for it via fmt.Stringer.
+		if s, ok := r.(fmt.Stringer); ok {
+			if str := s.String(); str != "" {
+				parts = append(parts, str)
+			}
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+func (m *gateMux) Type() string { return "mapStringBool" }
+
+// newGateMux builds a mux fronting the logging and driver registries.
+func newGateMux(logCfg *LoggingConfig) *gateMux {
+	return &gateMux{registries: []featuregate.MutableVersionedFeatureGate{
+		logCfg.FeatureGate(),
+		featuregates.FeatureGates(),
+	}}
+}
+
+// FeatureGatesString returns the aggregated enablement state of all gates
+// reachable through the --feature-gates flag (logging + driver registries),
+// suitable for a startup log line. Unlike featuregates.ToMap(), which reports
+// only the driver registry, this reflects everything the flag controls.
+func FeatureGatesString(logCfg *LoggingConfig) string {
+	return newGateMux(logCfg).String()
+}
+
+// FeatureGateFlags returns the single --feature-gates flag (env FEATURE_GATES)
+// backed by the logging and driver registries.
+func FeatureGateFlags(logCfg *LoggingConfig) []cli.Flag {
+	mux := newGateMux(logCfg)
+	var known []string
+	seen := map[string]struct{}{}
+	for _, r := range mux.registries {
+		for _, f := range r.KnownFeatures() {
+			name := strings.SplitN(f, "=", 2)[0]
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			known = append(known, f)
+		}
+	}
+	return []cli.Flag{
+		&cli.GenericFlag{
+			Name:     "feature-gates",
+			Category: "Feature Gates:",
+			Usage: "A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:\n     " +
+				strings.Join(known, "\n     "),
+			Value:   mux,
+			EnvVars: []string{"FEATURE_GATES"},
+		},
+	}
+}

--- a/pkg/flags/featuregates_test.go
+++ b/pkg/flags/featuregates_test.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"strings"
+	"testing"
+
+	cli "github.com/urfave/cli/v2"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
+)
+
+// buildTwoRegistries returns two independent registries: one owning "Alpha1",
+// one owning "Beta1", to exercise routing without depending on real gates.
+func buildTwoRegistries(t *testing.T) (featuregate.MutableVersionedFeatureGate, featuregate.MutableVersionedFeatureGate) {
+	t.Helper()
+	a := featuregate.NewVersionedFeatureGate(version.MajorMinor(0, 1))
+	if err := a.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		"Alpha1": {{Default: false, PreRelease: featuregate.Alpha, Version: version.MajorMinor(0, 1)}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	b := featuregate.NewVersionedFeatureGate(version.MajorMinor(0, 1))
+	if err := b.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		"Beta1": {{Default: false, PreRelease: featuregate.Alpha, Version: version.MajorMinor(0, 1)}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return a, b
+}
+
+func TestMuxRoutesEachKeyToOwner(t *testing.T) {
+	a, b := buildTwoRegistries(t)
+	mux := &gateMux{registries: []featuregate.MutableVersionedFeatureGate{a, b}}
+	if err := mux.Set("Alpha1=true,Beta1=true"); err != nil {
+		t.Fatalf("Set error: %v", err)
+	}
+	if !a.Enabled("Alpha1") {
+		t.Errorf("Alpha1 should be enabled in registry a")
+	}
+	if !b.Enabled("Beta1") {
+		t.Errorf("Beta1 should be enabled in registry b")
+	}
+}
+
+func TestMuxUnknownGateFailsFast(t *testing.T) {
+	a, b := buildTwoRegistries(t)
+	mux := &gateMux{registries: []featuregate.MutableVersionedFeatureGate{a, b}}
+	if err := mux.Set("Nope=true"); err == nil {
+		t.Fatalf("expected error for unknown gate")
+	}
+}
+
+func TestMuxRejectsMalformed(t *testing.T) {
+	a, b := buildTwoRegistries(t)
+	mux := &gateMux{registries: []featuregate.MutableVersionedFeatureGate{a, b}}
+	if err := mux.Set("Alpha1"); err == nil {
+		t.Fatalf("expected error for missing '='")
+	}
+	if err := mux.Set("Alpha1=notabool"); err == nil {
+		t.Fatalf("expected error for bad bool")
+	}
+}
+
+func TestMuxToleratesEmptySegments(t *testing.T) {
+	a, b := buildTwoRegistries(t)
+	mux := &gateMux{registries: []featuregate.MutableVersionedFeatureGate{a, b}}
+	if err := mux.Set("Alpha1=true,"); err != nil {
+		t.Fatalf("trailing comma should be tolerated, got %v", err)
+	}
+	if !a.Enabled("Alpha1") {
+		t.Errorf("Alpha1 should be enabled")
+	}
+}
+
+func TestMuxStringReflectsEnabledGates(t *testing.T) {
+	a, b := buildTwoRegistries(t)
+	mux := &gateMux{registries: []featuregate.MutableVersionedFeatureGate{a, b}}
+	if err := mux.Set("Alpha1=true"); err != nil {
+		t.Fatalf("Set error: %v", err)
+	}
+	if got := mux.String(); !strings.Contains(got, "Alpha1=true") {
+		t.Fatalf("String() should contain Alpha1=true, got %q", got)
+	}
+}
+
+func TestMuxRejectsMetaGates(t *testing.T) {
+	a, b := buildTwoRegistries(t)
+	mux := &gateMux{registries: []featuregate.MutableVersionedFeatureGate{a, b}}
+	for _, meta := range []string{"AllAlpha=true", "AllBeta=false"} {
+		if err := mux.Set(meta); err == nil {
+			t.Errorf("Set(%q) should be rejected", meta)
+		}
+	}
+	// A real gate is still unaffected and stays disabled.
+	if a.Enabled("Alpha1") {
+		t.Errorf("Alpha1 should not have been enabled by a rejected meta-gate set")
+	}
+}
+
+func TestMuxSetIsAtomicAcrossRegistries(t *testing.T) {
+	// Registry a owns a settable Alpha gate; registry b owns a GA gate locked to
+	// its default, so setting it to the non-default value fails inside SetFromMap
+	// (i.e. it passes parsing but fails to apply). The mux must not leave
+	// registry a's gate mutated when registry b's batch fails.
+	a := featuregate.NewVersionedFeatureGate(version.MajorMinor(0, 1))
+	if err := a.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		"Alpha1": {{Default: false, PreRelease: featuregate.Alpha, Version: version.MajorMinor(0, 1)}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	b := featuregate.NewVersionedFeatureGate(version.MajorMinor(0, 1))
+	if err := b.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		"Locked1": {{Default: true, PreRelease: featuregate.GA, LockToDefault: true, Version: version.MajorMinor(0, 1)}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	mux := &gateMux{registries: []featuregate.MutableVersionedFeatureGate{a, b}}
+	if err := mux.Set("Alpha1=true,Locked1=false"); err == nil {
+		t.Fatalf("expected Set to fail because Locked1 is locked to its default")
+	}
+	if a.Enabled("Alpha1") {
+		t.Errorf("Alpha1 must not be enabled when another registry's batch failed")
+	}
+}
+
+func TestFeatureGateFlagsSingleFlag(t *testing.T) {
+	logCfg := NewLoggingConfig()
+	flags := FeatureGateFlags(logCfg)
+	if len(flags) != 1 {
+		t.Fatalf("expected exactly one feature-gates flag, got %d", len(flags))
+	}
+	if flags[0].Names()[0] != "feature-gates" {
+		t.Fatalf("expected flag name feature-gates, got %v", flags[0].Names())
+	}
+	gf, ok := flags[0].(*cli.GenericFlag)
+	if !ok {
+		t.Fatalf("expected *cli.GenericFlag, got %T", flags[0])
+	}
+	if len(gf.EnvVars) != 1 || gf.EnvVars[0] != "FEATURE_GATES" {
+		t.Fatalf("expected EnvVars [FEATURE_GATES], got %v", gf.EnvVars)
+	}
+	if gf.Category != "Feature Gates:" {
+		t.Fatalf("expected category 'Feature Gates:', got %q", gf.Category)
+	}
+}
+
+func TestFeatureGateFlagsRouteLoggingAndReject(t *testing.T) {
+	logCfg := NewLoggingConfig()
+	mux := newGateMux(logCfg)
+	// The driver ships no gates of its own yet, so only logging gates are known
+	// through the shared flag. A logging gate routes to the logging registry.
+	if err := mux.Set("ContextualLogging=false"); err != nil {
+		t.Fatalf("logging gate should route: %v", err)
+	}
+	// A bogus gate is rejected by every registry, so the mux fails fast.
+	if err := mux.Set("Bogus=true"); err == nil {
+		t.Fatalf("bogus gate should fail")
+	}
+}

--- a/pkg/flags/logging.go
+++ b/pkg/flags/logging.go
@@ -52,7 +52,6 @@ type LoggingConfig struct {
 
 func NewLoggingConfig() *LoggingConfig {
 	fg := featuregate.NewFeatureGate()
-	var _ pflag.Value = fg // compile-time check for the type conversion below
 	l := &LoggingConfig{
 		featureGate: fg,
 		config:      logsapi.NewLoggingConfiguration(),
@@ -68,21 +67,16 @@ func (l *LoggingConfig) Apply() error {
 	return logsapi.ValidateAndApply(l.config, l.featureGate)
 }
 
+// FeatureGate exposes the logging feature-gate registry so it can be fronted by
+// the shared --feature-gates flag mux.
+func (l *LoggingConfig) FeatureGate() featuregate.MutableVersionedFeatureGate {
+	return l.featureGate
+}
+
 // Flags returns the flags for the configuration.
 func (l *LoggingConfig) Flags() []cli.Flag {
 	var fs pflag.FlagSet
 	logsapi.AddFlags(l.config, &fs)
-
-	// Adding the feature gates flag to fs means that its going to be added
-	// with "logging" as category. In practice, the logging code is the
-	// only code which uses the flag, therefore that seems like a good
-	// place to report it.
-	fs.AddFlag(&pflag.Flag{
-		Name: "feature-gates",
-		Usage: "A set of key=value pairs that describe feature gates for alpha/experimental features. " +
-			"Options are:\n     " + strings.Join(l.featureGate.KnownFeatures(), "\n     "),
-		Value: l.featureGate.(pflag.Value), //nolint:forcetypeassert // No need for type check: l.featureGate is a *featuregate.featureGate, which implements pflag.Value.
-	})
 
 	var flags []cli.Flag
 	fs.VisitAll(func(flag *pflag.Flag) {


### PR DESCRIPTION
## Summary

Adds a Kubernetes-style feature-gate mechanism so driver features that depend on Alpha/Beta upstream KEPs can ship disabled-by-default and be opted into per cluster. This PR delivers the **infrastructure only** — the driver registry ships empty; contributors register their own gates on top.

- **`pkg/featuregates`** — a driver-only `component-base` versioned registry (ships empty) with `Enabled` / `KnownFeatures` / `ToMap` / `ValidateFeatureGates` helpers. A commented `ExampleFeature` template shows contributors where and how to add a gate.
- **`pkg/flags`** — a `gateMux` (`pflag.Value`) that fronts both the existing logging feature-gate registry and the new driver registry behind a single `--feature-gates` flag (env `FEATURE_GATES`), routing each `key=value` to its owning registry and failing fast on unknown gates. Logging's own duplicate flag registration is removed.
- **`cmd/gpu-kubeletplugin`** — wires the flag, validates gates at startup, and logs the resolved gate state.
- **Helm** — exposes a `featureGates` map rendered into the `FEATURE_GATES` env var.

### Design notes

- Two separate registries (driver + logging) sit behind one flag, rather than merging them. This avoids the emulation-version / `PreAlpha` startup-panic class that arises from folding upstream logging gates (registered at Kubernetes versions) into a driver-SemVer-versioned registry.
- Unknown-gate fail-fast is inherited `component-base` behavior, preserved through the mux.

## Test plan

- [x] Unit tests: registry (empty-registry invariant, set/enable via a synthetic gate), mux (routing, fail-fast, malformed input, `String()` round-trip), flag constructor (single flag, env/category, driver+logging routing).
- [x] `make fmt` / `go vet` / `go build ./...` / `go test ./...` all green.
- [x] End-to-end on a DRA-enabled kind cluster: with a temporary gate wired to a discovery-path log line, verified the log is **absent** when the gate is unset (default) and **present** when set via `--set featureGates.<Name>=true` (rendered to `FEATURE_GATES`). Temporary test code was reverted before squashing.
