### PR TITLE
ci: stage release images to amdpsdo instead of pushing to rocm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,10 @@ jobs:
     if: github.repository == 'ROCm/k8s-gpu-dra-driver'
     uses: ROCm/common-infra-operator/.github/workflows/image-build-push.yaml@main
     with:
-      image-registry: docker.io/rocm
+      # Release images are staged to amdpsdo and promoted to docker.io/rocm
+      # manually. The published Helm chart still references docker.io/rocm, so
+      # do not publish the drafted release until the image has been promoted.
+      image-registry: docker.io/amdpsdo
       image-name: k8s-gpu-dra-driver
       image-tag: ${{ github.ref_name }}
       push: true


### PR DESCRIPTION
## Summary
The release workflow previously pushed the final release image directly to `docker.io/rocm`. This changes the release `image` job to push to `docker.io/amdpsdo` instead — the same registry the dev/CI pipeline (`image.yaml`) already uses — so a release image is **staged** in `amdpsdo` and then **manually promoted** to `docker.io/rocm` as a controlled step.

Only the image-push target changes. Credentials are unchanged (`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`), which already have `amdpsdo` push access.

## Important: chart vs. image registry
The published Helm chart (gh-pages) still references `docker.io/rocm/k8s-gpu-dra-driver:<version>` and continues to auto-publish on tag. After the workflow runs, that chart will reference an image that does **not** exist in `rocm` until it is manually promoted from `amdpsdo`.

The drafted GitHub release is the safety gate: **do not publish the drafted release until the release image has been promoted `amdpsdo` → `rocm`.** A comment to this effect is added in the workflow.

## Scope
- Targets `develop` only, per request — not backported to `release-v1.0.0`.

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [ ] Verified on next release tag: image appears in `docker.io/amdpsdo`, not `docker.io/rocm`