### PR TITLE
Add default DeviceClass extendedResourceName to amd.com/gpu

### DIFF
--- a/helm-charts-k8s/templates/deviceclass.yaml
+++ b/helm-charts-k8s/templates/deviceclass.yaml
@@ -9,4 +9,7 @@ spec:
   selectors:
   - cel:
       expression: "device.driver == 'gpu.amd.com'"
+  {{- with .Values.deviceClass.extendedResourceName }}
+  extendedResourceName: {{ . }}
+  {{- end }}
 {{- end }}

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -19,6 +19,9 @@ image:
 deviceClass:
   # -- Create the gpu.amd.com DeviceClass resource. Set to false if deploying via gpu-operator.
   create: true
+  # -- Maps classic extended-resource requests to this DeviceClass.
+  # Override to another name, or set "" to omit the field.
+  extendedResourceName: amd.com/gpu
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
## Motivation

For backward compatibility, we need to manually add a value for **extendedResourceName** . This PR defaults `DeviceClass` **extendedResourceName** to `amd.com/gpu` so classic extended-resource requests map to DRA without manual patching. Keep it overridable via Helm (deviceClass.extendedResourceName); set "" to omit. 

## Test plan

- [x] Override and empty-string omit behave as expected
- [x] ` helm template test ./helm-charts-k8s -n kube-amd-gpu --api-versions resource.k8s.io/v1` shows extendedResourceName: amd.com/gpu by default ( output below )

```yaml
# Source: k8s-gpu-dra-driver/templates/deviceclass.yaml
apiVersion: resource.k8s.io/v1
kind: DeviceClass
metadata:
  name: gpu.amd.com
spec:
  selectors:
  - cel:
      expression: "device.driver == 'gpu.amd.com'"
  extendedResourceName: amd.com/gpu
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
