### PR TITLE
fix: sort published ResourceSlice devices for a stable order

### DIFF
--- a/cmd/gpu-kubeletplugin/driver.go
+++ b/cmd/gpu-kubeletplugin/driver.go
@@ -33,11 +33,13 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -92,10 +94,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 	driver.helper = helper
 
-	devices := make([]resourceapi.Device, 0, len(state.allocatable))
-	for device := range maps.Values(state.allocatable) {
-		devices = append(devices, device.GetDevice())
-	}
+	devices := resourceSliceDevices(state.allocatable)
 	resources := resourceslice.DriverResources{
 		Pools: map[string]resourceslice.Pool{
 			config.flags.nodeName: {
@@ -124,6 +123,22 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 
 	return driver, nil
+}
+
+// resourceSliceDevices returns the allocatable devices sorted by name. Go map
+// iteration order is not specified, so without sorting the published
+// ResourceSlice would change on every restart. The order is also the first-fit
+// allocation priority the scheduler applies, so keeping it deterministic
+// matters beyond avoiding churn.
+func resourceSliceDevices(allocatable AllocatableDevices) []resourceapi.Device {
+	devices := make([]resourceapi.Device, 0, len(allocatable))
+	for device := range maps.Values(allocatable) {
+		devices = append(devices, device.GetDevice())
+	}
+	slices.SortFunc(devices, func(a, b resourceapi.Device) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return devices
 }
 
 func (d *driver) Shutdown(logger klog.Logger) error {

--- a/cmd/gpu-kubeletplugin/driver_test.go
+++ b/cmd/gpu-kubeletplugin/driver_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"slices"
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+func deviceNames(devices []resourceapi.Device) []string {
+	names := make([]string, len(devices))
+	for i, d := range devices {
+		names[i] = d.Name
+	}
+	return names
+}
+
+func TestResourceSliceDevicesAreSortedByName(t *testing.T) {
+	allocatable := AllocatableDevices{
+		"gpu-9-136":  {AmdGpu: &AmdGpuInfo{cardIndex: 9, renderIndex: 136}},
+		"gpu-1-128":  {AmdGpu: &AmdGpuInfo{cardIndex: 1, renderIndex: 128}},
+		"gpu-17-144": {AmdGpu: &AmdGpuInfo{cardIndex: 17, renderIndex: 144}},
+		"gpu-3-130":  {AmdGpu: &AmdGpuInfo{cardIndex: 3, renderIndex: 130}},
+		"gpu-11-138": {AmdGpu: &AmdGpuInfo{cardIndex: 11, renderIndex: 138}},
+	}
+
+	// The published Device.Name values in lexical order. gpu-11 sorts before
+	// gpu-3 because the names are compared as strings, not as numbers. Pinning
+	// the exact sequence checks that every device is kept (no drop, duplicate,
+	// or empty result) and documents the order, which the scheduler uses for
+	// first-fit allocation.
+	want := []string{
+		"gpu-1-128",
+		"gpu-11-138",
+		"gpu-17-144",
+		"gpu-3-130",
+		"gpu-9-136",
+	}
+
+	// Map iteration order is not defined, so repeating the call also catches an
+	// accidental removal of the sort.
+	for i := 0; i < 50; i++ {
+		got := deviceNames(resourceSliceDevices(allocatable))
+		if !slices.Equal(got, want) {
+			t.Fatalf("device order mismatch on call %d: got %v, want %v", i, got, want)
+		}
+	}
+}

--- a/cmd/gpu-kubeletplugin/driver_test.go
+++ b/cmd/gpu-kubeletplugin/driver_test.go
@@ -1,20 +1,4 @@
 /*
- * Copyright 2023 The Kubernetes Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
 Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the \"License\");


### PR DESCRIPTION
## Motivation

The ResourceSlice devices are collected from `state.allocatable` with `maps.Values`, and Go does not define map iteration order, so the published order changes between restarts even when the hardware is unchanged. That can rewrite the ResourceSlice on restart with no real change, and it makes the scheduler's first-fit device choice depend on map order.

## Change

Sort the devices by name before publishing, and add a unit test that checks the order is stable and sorted.
