### PR TITLE
fix: anchor binary .gitignore patterns so cmd/ sources are not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .config
 helm-charts-k8s/*.tgz
 
-# Binaries
-gpu-kubeletplugin
-webhook
+# Binaries built to the repo root. Anchor with a leading slash so the
+# cmd/ source directories of the same name are not ignored.
+/gpu-kubeletplugin
+/webhook


### PR DESCRIPTION
## Motivation

The `# Binaries` section ignores `gpu-kubeletplugin` and `webhook` with unanchored patterns, which also match the `cmd/gpu-kubeletplugin` and `cmd/webhook` source directories. New files under them (a `_test.go`, for example) are ignored, so they need `git add -f` and file-search tools skip them.

## Change

`make` builds these binaries to the repo root, so anchor the two patterns with a leading slash. The root binaries stay ignored and the source directories no longer are.
