### PR TITLE
fix: reset per-GPU identity in discovery so a device does not inherit the previous one

### DIFF
--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -95,8 +95,9 @@ func getPcieInfo(gpuInfoMap map[string]interface{}) (deviceattribute.DeviceAttri
 // discovered under the same name.
 func addAllocatableDevice(devices AllocatableDevices, device *AllocatableDevice) error {
 	name := device.CanonicalName()
-	if _, exists := devices[name]; exists {
-		return fmt.Errorf("duplicate device identity %q", name)
+	if existing, exists := devices[name]; exists {
+		return fmt.Errorf("duplicate device identity %q: already discovered as %s at %s, now %s at %s",
+			name, existing.Type(), existing.GetPCIAddress(), device.Type(), device.GetPCIAddress())
 	}
 	devices[name] = device
 	return nil

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -75,10 +75,8 @@ func getMemoryBytes(gpuInfoMap map[string]interface{}, deviceType, pciAddr strin
 
 func getPcieInfo(gpuInfoMap map[string]interface{}) (deviceattribute.DeviceAttribute, deviceattribute.DeviceAttribute, string, error) {
 	pciAddr := gpuInfoMap["pciAddr"].(string)
-	// The PCIe root and bus-id attributes are optional NUMA/topology hints; the caller
-	// keeps going without them. The device's own BDF is known regardless, so return it
-	// even on error rather than an empty string that would leave a partition's parent
-	// PCIAddress blank.
+	// The attributes are optional hints and the caller continues without them, but the BDF is
+	// always known, so return it even on error; an empty one blanks a partition's parent.
 	pcieRootAttr, err := deviceattribute.GetPCIeRootAttributeByPCIBusID(pciAddr)
 	if err != nil {
 		return pcieRootAttr, deviceattribute.DeviceAttribute{}, pciAddr, fmt.Errorf("Failed to get PCIe root attribute for device %s: %v", pciAddr, err)
@@ -103,10 +101,9 @@ func addAllocatableDevice(devices AllocatableDevices, device *AllocatableDevice)
 	return nil
 }
 
-// isComputePartition reports whether t names a partition rather than a whole GPU: an empty
-// type means no partitioning support and spx is the single-partition mode. The mode only
-// feeds the published profile string, so matching a fixed set of modes here would drop
-// valid partitions for any mode not listed, such as tpx on MI300A.
+// isComputePartition reports whether t names a partition rather than a whole GPU. An empty
+// type means no partitioning support, and spx is the single-partition mode. Every other
+// mode is a partition, including ones newer than this driver, such as tpx.
 func isComputePartition(t string) bool {
 	return t != "" && t != consts.ComputePartitionSPX
 }
@@ -166,8 +163,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 				device.CanonicalName(), computePartitionType, memoryPartitionType)
 		} else {
 			// This is a partition - create both parent GPU info and partition info.
-			// A well-formed profile needs both halves; an empty memory type would produce
-			// a truncated "dpx_" profile, so skip an incomplete one rather than publish it.
+			// An empty memory type gives a truncated "dpx_" profile, so skip it instead.
 			if memoryPartitionType == "" {
 				klog.Warningf("Skipping partition for device %s: compute type %q has no memory partition type", pciAddr, computePartitionType)
 				continue

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -101,11 +101,20 @@ func addAllocatableDevice(devices AllocatableDevices, device *AllocatableDevice)
 	return nil
 }
 
-// isComputePartition reports whether t names a partition rather than a whole GPU. An empty
-// type means no partitioning support, and spx is the single-partition mode. Every other
-// mode is a partition, including ones newer than this driver, such as tpx.
-func isComputePartition(t string) bool {
-	return t != "" && t != consts.ComputePartitionSPX
+// classifyComputePartition reports whether t names a partition rather than a whole GPU.
+// An empty type means no partitioning support and spx is the single-partition mode, so
+// both are whole GPUs. A mode this driver does not know is an error: publishing it would
+// turn hardware state the driver cannot interpret into a schedulable device.
+func classifyComputePartition(t string) (bool, error) {
+	switch t {
+	case "", consts.ComputePartitionSPX:
+		return false, nil
+	case consts.ComputePartitionDPX, consts.ComputePartitionTPX,
+		consts.ComputePartitionQPX, consts.ComputePartitionCPX:
+		return true, nil
+	default:
+		return false, fmt.Errorf("unsupported compute partition mode %q", t)
+	}
 }
 
 func enumerateAllPossibleDevices() (AllocatableDevices, error) {
@@ -127,7 +136,12 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 		// Extract common topology information
 		simdUnits, computeUnits := extractTopologyInfo(gpuInfoMap)
 
-		if !isComputePartition(computePartitionType) {
+		isPartition, err := classifyComputePartition(computePartitionType)
+		if err != nil {
+			return nil, fmt.Errorf("device %s: %w", pciAddr, err)
+		}
+
+		if !isPartition {
 			// This is a full AMD GPU (either explicitly "spx" or no partition support)
 			partitionProfile := ""
 			if computePartitionType != "" && memoryPartitionType != "" {

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -75,13 +75,17 @@ func getMemoryBytes(gpuInfoMap map[string]interface{}, deviceType, pciAddr strin
 
 func getPcieInfo(gpuInfoMap map[string]interface{}) (deviceattribute.DeviceAttribute, deviceattribute.DeviceAttribute, string, error) {
 	pciAddr := gpuInfoMap["pciAddr"].(string)
+	// The PCIe root and bus-id attributes are optional NUMA/topology hints; the caller
+	// keeps going without them. The device's own BDF is known regardless, so return it
+	// even on error rather than an empty string that would leave a partition's parent
+	// PCIAddress blank.
 	pcieRootAttr, err := deviceattribute.GetPCIeRootAttributeByPCIBusID(pciAddr)
 	if err != nil {
-		return pcieRootAttr, deviceattribute.DeviceAttribute{}, "", fmt.Errorf("Failed to get PCIe root attribute for device %s: %v", pciAddr, err)
+		return pcieRootAttr, deviceattribute.DeviceAttribute{}, pciAddr, fmt.Errorf("Failed to get PCIe root attribute for device %s: %v", pciAddr, err)
 	}
 	pciBusIDAttr, err := deviceattribute.GetPCIBusIDAttribute(pciAddr)
 	if err != nil {
-		return pcieRootAttr, pciBusIDAttr, "", fmt.Errorf("Failed to get PCI Bus ID attribute for device %s: %v", pciAddr, err)
+		return pcieRootAttr, pciBusIDAttr, pciAddr, fmt.Errorf("Failed to get PCI Bus ID attribute for device %s: %v", pciAddr, err)
 	}
 	return pcieRootAttr, pciBusIDAttr, pciAddr, nil
 }
@@ -96,6 +100,19 @@ func addAllocatableDevice(devices AllocatableDevices, device *AllocatableDevice)
 	}
 	devices[name] = device
 	return nil
+}
+
+// isKnownComputePartition reports whether t is a compute-partition mode this driver
+// models. spx is a full GPU and is handled separately. A type outside this set means the
+// driver cannot model the device's partitioning, so discovery skips it rather than
+// publishing a device with an unhandled profile; a new AMD mode has to be added here.
+func isKnownComputePartition(t string) bool {
+	switch t {
+	case consts.ComputePartitionDPX, consts.ComputePartitionQPX, consts.ComputePartitionCPX:
+		return true
+	default:
+		return false
+	}
 }
 
 func enumerateAllPossibleDevices() (AllocatableDevices, error) {
@@ -151,8 +168,14 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 
 			klog.Infof("Found full AMD GPU: %s, compute type: %s, memory type: %s",
 				device.CanonicalName(), computePartitionType, memoryPartitionType)
-		} else if computePartitionType != "" {
-			// This is a partition - create both parent GPU info and partition info
+		} else if isKnownComputePartition(computePartitionType) {
+			// This is a partition - create both parent GPU info and partition info.
+			// A well-formed profile needs both halves; an empty memory type would produce
+			// a truncated "dpx_" profile, so skip an incomplete one rather than publish it.
+			if memoryPartitionType == "" {
+				klog.Warningf("Skipping partition for device %s: compute type %q has no memory partition type", pciAddr, computePartitionType)
+				continue
+			}
 
 			// Create parent GPU info
 			parentGpuInfo := &AmdGpuInfo{
@@ -188,7 +211,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 			klog.Infof("Found AMD GPU partition: %s, compute type: %s, memory type: %s",
 				device.CanonicalName(), computePartitionType, memoryPartitionType)
 		} else {
-			klog.Warningf("Unknown compute partition type '%s' for device %s, skipping", computePartitionType, pciAddr)
+			klog.Warningf("Skipping device %s: unsupported compute partition type %q", pciAddr, computePartitionType)
 		}
 	}
 

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -86,6 +86,18 @@ func getPcieInfo(gpuInfoMap map[string]interface{}) (deviceattribute.DeviceAttri
 	return pcieRootAttr, pciBusIDAttr, pciAddr, nil
 }
 
+// addAllocatableDevice inserts a device under its canonical name, returning an
+// error on a name collision instead of silently overwriting a device already
+// discovered under the same name.
+func addAllocatableDevice(devices AllocatableDevices, device *AllocatableDevice) error {
+	name := device.CanonicalName()
+	if _, exists := devices[name]; exists {
+		return fmt.Errorf("duplicate device identity %q", name)
+	}
+	devices[name] = device
+	return nil
+}
+
 func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 	alldevices := make(AllocatableDevices)
 	allAMDGPUs := amdgpu.GetAMDGPUs()
@@ -133,7 +145,9 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 			device := &AllocatableDevice{
 				AmdGpu: amdGpuInfo,
 			}
-			alldevices[device.CanonicalName()] = device
+			if err := addAllocatableDevice(alldevices, device); err != nil {
+				return nil, err
+			}
 
 			klog.Infof("Found full AMD GPU: %s, compute type: %s, memory type: %s",
 				device.CanonicalName(), computePartitionType, memoryPartitionType)
@@ -167,7 +181,9 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 			device := &AllocatableDevice{
 				AmdPartition: partitionInfo,
 			}
-			alldevices[device.CanonicalName()] = device
+			if err := addAllocatableDevice(alldevices, device); err != nil {
+				return nil, err
+			}
 
 			klog.Infof("Found AMD GPU partition: %s, compute type: %s, memory type: %s",
 				device.CanonicalName(), computePartitionType, memoryPartitionType)

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -117,6 +117,19 @@ func classifyComputePartition(t string) (bool, error) {
 	}
 }
 
+// classifyMemoryPartition rejects a memory mode the driver cannot interpret. The kernel
+// reports UNKNOWN when it cannot read the mode, and pairing that with a known compute
+// mode would publish a profile like "dpx_unknown" for the scheduler to match on.
+func classifyMemoryPartition(t string) error {
+	switch t {
+	case consts.MemoryPartitionNPS1, consts.MemoryPartitionNPS2, consts.MemoryPartitionNPS3,
+		consts.MemoryPartitionNPS4, consts.MemoryPartitionNPS6, consts.MemoryPartitionNPS8:
+		return nil
+	default:
+		return fmt.Errorf("unsupported memory partition mode %q", t)
+	}
+}
+
 func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 	alldevices := make(AllocatableDevices)
 	allAMDGPUs := amdgpu.GetAMDGPUs()
@@ -178,9 +191,8 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 		} else {
 			// This is a partition - create both parent GPU info and partition info.
 			// An empty memory type gives a truncated "dpx_" profile, so skip it instead.
-			if memoryPartitionType == "" {
-				klog.Warningf("Skipping partition for device %s: compute type %q has no memory partition type", pciAddr, computePartitionType)
-				continue
+			if err := classifyMemoryPartition(memoryPartitionType); err != nil {
+				return nil, fmt.Errorf("device %s: %w", pciAddr, err)
 			}
 
 			// Create parent GPU info

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -103,17 +103,12 @@ func addAllocatableDevice(devices AllocatableDevices, device *AllocatableDevice)
 	return nil
 }
 
-// isKnownComputePartition reports whether t is a compute-partition mode this driver
-// models. spx is a full GPU and is handled separately. A type outside this set means the
-// driver cannot model the device's partitioning, so discovery skips it rather than
-// publishing a device with an unhandled profile; a new AMD mode has to be added here.
-func isKnownComputePartition(t string) bool {
-	switch t {
-	case consts.ComputePartitionDPX, consts.ComputePartitionQPX, consts.ComputePartitionCPX:
-		return true
-	default:
-		return false
-	}
+// isComputePartition reports whether t names a partition rather than a whole GPU: an empty
+// type means no partitioning support and spx is the single-partition mode. The mode only
+// feeds the published profile string, so matching a fixed set of modes here would drop
+// valid partitions for any mode not listed, such as tpx on MI300A.
+func isComputePartition(t string) bool {
+	return t != "" && t != consts.ComputePartitionSPX
 }
 
 func enumerateAllPossibleDevices() (AllocatableDevices, error) {
@@ -135,7 +130,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 		// Extract common topology information
 		simdUnits, computeUnits := extractTopologyInfo(gpuInfoMap)
 
-		if computePartitionType == consts.ComputePartitionSPX || computePartitionType == "" {
+		if !isComputePartition(computePartitionType) {
 			// This is a full AMD GPU (either explicitly "spx" or no partition support)
 			partitionProfile := ""
 			if computePartitionType != "" && memoryPartitionType != "" {
@@ -169,7 +164,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 
 			klog.Infof("Found full AMD GPU: %s, compute type: %s, memory type: %s",
 				device.CanonicalName(), computePartitionType, memoryPartitionType)
-		} else if isKnownComputePartition(computePartitionType) {
+		} else {
 			// This is a partition - create both parent GPU info and partition info.
 			// A well-formed profile needs both halves; an empty memory type would produce
 			// a truncated "dpx_" profile, so skip an incomplete one rather than publish it.
@@ -211,8 +206,6 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 
 			klog.Infof("Found AMD GPU partition: %s, compute type: %s, memory type: %s",
 				device.CanonicalName(), computePartitionType, memoryPartitionType)
-		} else {
-			klog.Warningf("Skipping device %s: unsupported compute partition type %q", pciAddr, computePartitionType)
 		}
 	}
 

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -154,6 +154,14 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 			return nil, fmt.Errorf("device %s: %w", pciAddr, err)
 		}
 
+		// Both paths concatenate this into the profile, so neither may carry a mode the
+		// driver cannot interpret. Empty means the kernel exposes no memory partitioning.
+		if memoryPartitionType != "" {
+			if err := classifyMemoryPartition(memoryPartitionType); err != nil {
+				return nil, fmt.Errorf("device %s: %w", pciAddr, err)
+			}
+		}
+
 		if !isPartition {
 			// This is a full AMD GPU (either explicitly "spx" or no partition support)
 			partitionProfile := ""
@@ -191,8 +199,8 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 		} else {
 			// This is a partition - create both parent GPU info and partition info.
 			// An empty memory type gives a truncated "dpx_" profile, so skip it instead.
-			if err := classifyMemoryPartition(memoryPartitionType); err != nil {
-				return nil, fmt.Errorf("device %s: %w", pciAddr, err)
+			if memoryPartitionType == "" {
+				return nil, fmt.Errorf("device %s: compute partition %q has no memory partition mode", pciAddr, computePartitionType)
 			}
 
 			// Create parent GPU info

--- a/cmd/gpu-kubeletplugin/discovery_identity_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_identity_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+// Two devices that resolve to the same canonical name must not silently overwrite
+// each other; discovery reports the collision instead of dropping a GPU.
+func TestAddAllocatableDeviceRejectsCollision(t *testing.T) {
+	devices := make(AllocatableDevices)
+	first := &AllocatableDevice{AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128}}
+	if err := addAllocatableDevice(devices, first); err != nil {
+		t.Fatalf("first insert: unexpected error %v", err)
+	}
+
+	dup := &AllocatableDevice{AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128}}
+	if err := addAllocatableDevice(devices, dup); err == nil {
+		t.Fatalf("colliding insert: want an error, got nil")
+	}
+	if devices[first.CanonicalName()] != first {
+		t.Fatalf("colliding insert overwrote the original device")
+	}
+}

--- a/cmd/gpu-kubeletplugin/discovery_identity_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_identity_test.go
@@ -46,23 +46,32 @@ func TestAddAllocatableDeviceRejectsCollision(t *testing.T) {
 	}
 }
 
-// Every mode other than spx and the empty type is a partition. tpx matters most: it is real
-// on MI300A, so treating it as unknown drops those partitions entirely.
-func TestIsComputePartition(t *testing.T) {
+// Each of the modes AMD defines is classified, and anything else is an error rather than
+// a guess: publishing a mode the driver cannot interpret would turn unknown hardware
+// state into an allocatable device, and skipping it would lose the GPU silently.
+func TestClassifyComputePartition(t *testing.T) {
 	for _, tc := range []struct {
-		in   string
-		want bool
+		in        string
+		partition bool
+		wantErr   bool
 	}{
-		{"dpx", true},
-		{"tpx", true}, // valid on MI300A
-		{"qpx", true},
-		{"cpx", true},
-		{"spx", false}, // the single-partition mode, classified as a full GPU
-		{"", false},    // no partitioning support
-		{"zpx", true},  // a mode added after this driver was written stays a partition
+		{in: "dpx", partition: true},
+		{in: "tpx", partition: true}, // valid on MI300A
+		{in: "qpx", partition: true},
+		{in: "cpx", partition: true},
+		{in: "spx"}, // the single-partition mode is a whole GPU
+		{in: ""},    // no partitioning support
+		{in: "invalid", wantErr: true},
+		{in: "unknown", wantErr: true},
+		{in: "zpx", wantErr: true},
 	} {
-		if got := isComputePartition(tc.in); got != tc.want {
-			t.Errorf("isComputePartition(%q) = %v, want %v", tc.in, got, tc.want)
+		got, err := classifyComputePartition(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("classifyComputePartition(%q) error = %v, wantErr %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if got != tc.partition {
+			t.Errorf("classifyComputePartition(%q) = %v, want %v", tc.in, got, tc.partition)
 		}
 	}
 }

--- a/cmd/gpu-kubeletplugin/discovery_identity_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_identity_test.go
@@ -46,9 +46,8 @@ func TestAddAllocatableDeviceRejectsCollision(t *testing.T) {
 	}
 }
 
-// Every mode other than spx and the empty type is a partition. tpx in particular has to
-// be one: it is a real mode on MI300A, and matching against a fixed set of modes would
-// drop those partitions from the published devices entirely.
+// Every mode other than spx and the empty type is a partition. tpx matters most: it is real
+// on MI300A, so treating it as unknown drops those partitions entirely.
 func TestIsComputePartition(t *testing.T) {
 	for _, tc := range []struct {
 		in   string

--- a/cmd/gpu-kubeletplugin/discovery_identity_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_identity_test.go
@@ -46,23 +46,24 @@ func TestAddAllocatableDeviceRejectsCollision(t *testing.T) {
 	}
 }
 
-// Only the compute-partition modes the driver models are treated as partitions; spx is a
-// full GPU and anything else is skipped rather than published with an unhandled profile.
-func TestIsKnownComputePartition(t *testing.T) {
+// Every mode other than spx and the empty type is a partition. tpx in particular has to
+// be one: it is a real mode on MI300A, and matching against a fixed set of modes would
+// drop those partitions from the published devices entirely.
+func TestIsComputePartition(t *testing.T) {
 	for _, tc := range []struct {
 		in   string
 		want bool
 	}{
 		{"dpx", true},
+		{"tpx", true}, // valid on MI300A
 		{"qpx", true},
 		{"cpx", true},
-		{"spx", false}, // spx is a full GPU, classified separately
-		{"", false},
-		{"tpx", false},     // a mode this driver does not model
-		{"garbage", false}, // an unreadable or unexpected value
+		{"spx", false}, // the single-partition mode, classified as a full GPU
+		{"", false},    // no partitioning support
+		{"zpx", true},  // a mode added after this driver was written stays a partition
 	} {
-		if got := isKnownComputePartition(tc.in); got != tc.want {
-			t.Errorf("isKnownComputePartition(%q) = %v, want %v", tc.in, got, tc.want)
+		if got := isComputePartition(tc.in); got != tc.want {
+			t.Errorf("isComputePartition(%q) = %v, want %v", tc.in, got, tc.want)
 		}
 	}
 }

--- a/cmd/gpu-kubeletplugin/discovery_identity_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_identity_test.go
@@ -35,3 +35,38 @@ func TestAddAllocatableDeviceRejectsCollision(t *testing.T) {
 		t.Fatalf("colliding insert overwrote the original device")
 	}
 }
+
+// Only the compute-partition modes the driver models are treated as partitions; spx is a
+// full GPU and anything else is skipped rather than published with an unhandled profile.
+func TestIsKnownComputePartition(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"dpx", true},
+		{"qpx", true},
+		{"cpx", true},
+		{"spx", false}, // spx is a full GPU, classified separately
+		{"", false},
+		{"tpx", false},     // a mode this driver does not model
+		{"garbage", false}, // an unreadable or unexpected value
+	} {
+		if got := isKnownComputePartition(tc.in); got != tc.want {
+			t.Errorf("isKnownComputePartition(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// An optional PCIe attribute lookup can fail, but the device's own BDF is always known, so
+// getPcieInfo must return it rather than an empty string, otherwise a partition's parent
+// PCIAddress ends up blank.
+func TestGetPcieInfoPreservesBDFOnError(t *testing.T) {
+	const bogus = "0000:ff:ff.7" // no such device, so the attribute lookup fails
+	_, _, addr, err := getPcieInfo(map[string]interface{}{"pciAddr": bogus})
+	if err == nil {
+		t.Fatalf("want an error for a nonexistent BDF, got nil")
+	}
+	if addr != bogus {
+		t.Errorf("getPcieInfo returned addr %q on error, want the input BDF %q", addr, bogus)
+	}
+}

--- a/cmd/gpu-kubeletplugin/discovery_identity_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_identity_test.go
@@ -16,20 +16,30 @@ limitations under the License.
 
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-// Two devices that resolve to the same canonical name must not silently overwrite
-// each other; discovery reports the collision instead of dropping a GPU.
+// Two devices that resolve to the same canonical name must not silently overwrite each
+// other; discovery reports the collision, with the provenance of both sides, instead of
+// dropping a GPU.
 func TestAddAllocatableDeviceRejectsCollision(t *testing.T) {
 	devices := make(AllocatableDevices)
-	first := &AllocatableDevice{AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128}}
+	first := &AllocatableDevice{AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128, PCIAddress: "0000:03:00.0"}}
 	if err := addAllocatableDevice(devices, first); err != nil {
 		t.Fatalf("first insert: unexpected error %v", err)
 	}
 
-	dup := &AllocatableDevice{AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128}}
-	if err := addAllocatableDevice(devices, dup); err == nil {
+	dup := &AllocatableDevice{AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128, PCIAddress: "0000:04:00.0"}}
+	err := addAllocatableDevice(devices, dup)
+	if err == nil {
 		t.Fatalf("colliding insert: want an error, got nil")
+	}
+	for _, want := range []string{"0000:03:00.0", "0000:04:00.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("collision error %q should name the colliding device %s", err, want)
+		}
 	}
 	if devices[first.CanonicalName()] != first {
 		t.Fatalf("colliding insert overwrote the original device")

--- a/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ROCm/k8s-gpu-dra-driver/pkg/amdgpu"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGPU describes one physical AMD GPU to lay out under a fake sysfs root.
+type fakeGPU struct {
+	pciAddr      string
+	card, render int
+	computeMode  string
+	memoryMode   string
+	bus, dev     int
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// fakeSysfs lays out the sysfs entries GetAMDGPUs reads and points the package
+// path variables at it, so discovery can run with no AMD hardware present.
+func fakeSysfs(t *testing.T, gpus []fakeGPU) {
+	t.Helper()
+	root := t.TempDir()
+	amdgpu.SetSysfsRoot(root)
+	t.Cleanup(amdgpu.ResetSysfsRoot)
+
+	node := 1
+	for _, g := range gpus {
+		dir := filepath.Join(root, "sys/module/amdgpu/drivers/pci:amdgpu", g.pciAddr)
+		writeFile(t, filepath.Join(dir, "current_compute_partition"), g.computeMode)
+		writeFile(t, filepath.Join(dir, "current_memory_partition"), g.memoryMode)
+		writeFile(t, filepath.Join(dir, "numa_node"), "0")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "drm", fmt.Sprintf("card%d", g.card)), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "drm", fmt.Sprintf("renderD%d", g.render)), 0o755))
+
+		writeFile(t, filepath.Join(root, "sys/class/drm", fmt.Sprintf("card%d", g.card), "device/product_name"), "Instinct MI300A\n")
+
+		// location_id packs bus and device; discovery derives the kfd id from it.
+		locationID := g.bus<<8 | g.dev<<3
+		props := fmt.Sprintf("drm_render_minor %d\nlocation_id %d\ndomain 0\nsimd_count 304\nsimd_per_cu 4\nsize_in_bytes 137438953472\n", g.render, locationID)
+		writeFile(t, filepath.Join(root, "sys/class/kfd/kfd/topology/nodes", fmt.Sprint(node), "properties"), props)
+		node++
+	}
+}
+
+// A GPU reporting a partition mode this driver was not written against must still be
+// discovered. tpx is the concrete case: it is valid on MI300A.
+func TestEnumerateDiscoversUnlistedPartitionMode(t *testing.T) {
+	for _, mode := range []string{"dpx", "tpx", "qpx", "cpx"} {
+		t.Run(mode, func(t *testing.T) {
+			fakeSysfs(t, []fakeGPU{
+				{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: mode, memoryMode: "nps1", bus: 0x19, dev: 0},
+			})
+
+			devices, err := enumerateAllPossibleDevices()
+			require.NoError(t, err)
+			require.Len(t, devices, 1, "the %s device must be discovered", mode)
+
+			for name, d := range devices {
+				require.NotNil(t, d.AmdPartition, "%s must be modelled as a partition, got %s", mode, d.Type())
+				require.Equal(t, mode+"_nps1", d.AmdPartition.PartitionProfile)
+				t.Logf("%s -> %s profile=%s", mode, name, d.AmdPartition.PartitionProfile)
+			}
+		})
+	}
+}
+
+// fakeXCP adds a platform XCP partition that belongs to the physical GPU at the same
+// bus/device, which is how discovery ties a partition to its parent.
+func fakeXCP(t *testing.T, xcpIndex, card, render, bus, dev, node int) {
+	t.Helper()
+	root := filepath.Dir(filepath.Dir(filepath.Dir(amdgpu.PlatformDevicesPath)))
+	xcp := filepath.Join(amdgpu.PlatformDevicesPath, fmt.Sprintf("amdgpu_xcp_%d", xcpIndex))
+	require.NoError(t, os.MkdirAll(filepath.Join(xcp, "drm", fmt.Sprintf("card%d", card)), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(xcp, "drm", fmt.Sprintf("renderD%d", render)), 0o755))
+
+	locationID := bus<<8 | dev<<3
+	props := fmt.Sprintf("drm_render_minor %d\nlocation_id %d\ndomain 0\nsimd_count 38\nsimd_per_cu 4\nsize_in_bytes 17179869184\n", render, locationID)
+	writeFile(t, filepath.Join(root, "sys/class/kfd/kfd/topology/nodes", fmt.Sprint(node), "properties"), props)
+}
+
+// Every partition must inherit the PCI address of the physical GPU that shares its kfd
+// id, and must do so on every run. The parent lookup used to scan a map the loop was
+// appending partitions to, so a later partition could match an earlier one instead.
+func TestEnumerateAttachesPartitionsToPhysicalParent(t *testing.T) {
+	for run := 0; run < 40; run++ {
+		func() {
+			fakeSysfs(t, []fakeGPU{
+				{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "cpx", memoryMode: "nps1", bus: 0x19, dev: 0},
+			})
+			fakeXCP(t, 30, 1, 129, 0x19, 0, 10)
+			fakeXCP(t, 31, 2, 130, 0x19, 0, 11)
+			fakeXCP(t, 32, 3, 131, 0x19, 0, 12)
+
+			devices, err := enumerateAllPossibleDevices()
+			require.NoError(t, err)
+
+			partitions := 0
+			for name, d := range devices {
+				if d.AmdPartition == nil {
+					continue
+				}
+				partitions++
+				require.NotNil(t, d.AmdPartition.Parent, "%s has no parent", name)
+				require.Equal(t, "0000:19:00.0", d.AmdPartition.Parent.PCIAddress,
+					"run %d: %s did not inherit the physical parent BDF", run, name)
+			}
+			require.Equal(t, 4, partitions, "run %d: expected 4 partitions (the cpx physical entry plus 3 XCPs), got %d", run, partitions)
+		}()
+	}
+}
+
+// A GPU whose DRM entries are missing must be skipped, and must not be published with
+// the previous GPU's card, render, or kfd identity. This is the carry-over this PR
+// removes, checked through discovery rather than the helper alone.
+func TestEnumerateSkipsIncompleteIdentityWithoutBorrowing(t *testing.T) {
+	fakeSysfs(t, []fakeGPU{
+		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "spx", memoryMode: "nps1", bus: 0x19, dev: 0},
+	})
+	// A second amdgpu-bound device with no drm entries and no topology node.
+	incomplete := filepath.Join(amdgpu.AMDGPUDriversPath, "pci:amdgpu", "0000:1a:00.0")
+	writeFile(t, filepath.Join(incomplete, "current_compute_partition"), "spx")
+	writeFile(t, filepath.Join(incomplete, "current_memory_partition"), "nps1")
+	writeFile(t, filepath.Join(incomplete, "numa_node"), "0")
+
+	devices, err := enumerateAllPossibleDevices()
+	require.NoError(t, err)
+
+	for name, d := range devices {
+		t.Logf("discovered %s (%s)", name, d.Type())
+	}
+	require.Len(t, devices, 1, "only the complete GPU may be published")
+	_, ok := devices["gpu-0-128"]
+	require.True(t, ok, "the complete GPU keeps its own identity")
+}

--- a/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
@@ -249,3 +249,57 @@ func TestEnumerateWithoutRetryLosesLateDRMEntries(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, devices, "a single attempt cannot see entries that appear later")
 }
+
+// Only one of the two partition files present is a partial read of a changing tree, not
+// a GPU without partitioning support, so it must be retried rather than published whole.
+func TestEnumerateRetriesOnHalfPresentPartitionState(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)()
+	for _, missing := range []string{"current_memory_partition", "current_compute_partition"} {
+		t.Run("missing "+missing, func(t *testing.T) {
+			fakeSysfs(t, []fakeGPU{
+				{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "dpx", memoryMode: "nps1", bus: 0x19, dev: 0},
+			})
+			require.NoError(t, os.Remove(filepath.Join(amdgpu.AMDGPUDriversPath, "pci:amdgpu", "0000:19:00.0", missing)))
+
+			devices, err := enumerateAllPossibleDevices()
+			require.NoError(t, err)
+			require.Empty(t, devices, "a half-present partition state must not be published")
+		})
+	}
+}
+
+// A memory mode the driver cannot interpret must not be paired with a known compute mode
+// into a profile the scheduler can select on.
+func TestEnumerateRejectsUnknownMemoryMode(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)()
+	for _, mode := range []string{"unknown", "garbage"} {
+		t.Run(mode, func(t *testing.T) {
+			fakeSysfs(t, []fakeGPU{
+				{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "dpx", memoryMode: mode, bus: 0x19, dev: 0},
+			})
+			_, err := enumerateAllPossibleDevices()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), mode)
+		})
+	}
+}
+
+// The amdgpu sysfs root disappearing during a driver reload must stay retryable instead
+// of reading as a completed discovery that happens to have found nothing.
+func TestEnumerateDoesNotAcceptAVanishedDriverRoot(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(20, 20*time.Millisecond)()
+	fakeSysfs(t, []fakeGPU{
+		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "spx", memoryMode: "nps1", bus: 0x19, dev: 0},
+	})
+	root := amdgpu.AMDGPUDriversPath
+	stash := root + ".away"
+	require.NoError(t, os.Rename(root, stash))
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = os.Rename(stash, root)
+	}()
+
+	devices, err := enumerateAllPossibleDevices()
+	require.NoError(t, err)
+	require.Contains(t, devices, "gpu-0-128", "the GPU must be found once the driver root is back")
+}

--- a/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
@@ -158,3 +158,53 @@ func TestEnumerateSkipsIncompleteIdentityWithoutBorrowing(t *testing.T) {
 	_, ok := devices["gpu-0-128"]
 	require.True(t, ok, "the complete GPU keeps its own identity")
 }
+
+// A mode the driver does not know must stop discovery rather than be published as a
+// partition, since nothing downstream can interpret its allocation semantics.
+func TestEnumerateRejectsUnknownPartitionMode(t *testing.T) {
+	for _, mode := range []string{"zpx", "invalid", "unknown"} {
+		t.Run(mode, func(t *testing.T) {
+			fakeSysfs(t, []fakeGPU{
+				{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: mode, memoryMode: "nps1", bus: 0x19, dev: 0},
+			})
+			_, err := enumerateAllPossibleDevices()
+			require.Error(t, err, "%q must not be published as a partition", mode)
+			require.Contains(t, err.Error(), mode)
+		})
+	}
+}
+
+// An unreadable partition file must not read as "no partitioning support": that would
+// publish a partitioned GPU as one whole allocatable device.
+func TestEnumerateSkipsDeviceWithUnreadablePartitionFile(t *testing.T) {
+	fakeSysfs(t, []fakeGPU{
+		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "cpx", memoryMode: "nps1", bus: 0x19, dev: 0},
+	})
+	// Replace the file with a directory so the read fails as EISDIR for any user.
+	p := filepath.Join(amdgpu.AMDGPUDriversPath, "pci:amdgpu", "0000:19:00.0", "current_compute_partition")
+	require.NoError(t, os.Remove(p))
+	require.NoError(t, os.MkdirAll(p, 0o755))
+
+	devices, err := enumerateAllPossibleDevices()
+	require.NoError(t, err)
+	require.Empty(t, devices, "an unreadable partition mode must not become a whole GPU")
+}
+
+// A GPU in a partition mode whose KFD identity is not ready yet must not be published:
+// its partitions are skipped for the same missing id, so it would advertise part of a
+// partitioned GPU as if it were the whole topology.
+func TestEnumerateSkipsPartitionedGPUWithoutKFDIdentity(t *testing.T) {
+	for _, mode := range []string{"dpx", "tpx"} {
+		t.Run(mode, func(t *testing.T) {
+			fakeSysfs(t, []fakeGPU{
+				{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: mode, memoryMode: "nps1", bus: 0x19, dev: 0},
+			})
+			// Drop the topology node so the kfd identity cannot resolve.
+			require.NoError(t, os.RemoveAll(filepath.Join(amdgpu.KFDTopologyPath, "topology")))
+
+			devices, err := enumerateAllPossibleDevices()
+			require.NoError(t, err)
+			require.Empty(t, devices, "no partial topology may be published for %s", mode)
+		})
+	}
+}

--- a/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
@@ -284,6 +284,35 @@ func TestEnumerateRejectsUnknownMemoryMode(t *testing.T) {
 	}
 }
 
+// The whole-GPU path concatenates the memory mode into the profile as well, so a mode the
+// driver cannot interpret has to be rejected there too rather than published as spx_<mode>.
+func TestEnumerateRejectsUnknownMemoryModeOnWholeGPU(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)()
+	for _, mode := range []string{"unknown", "garbage", "nps5"} {
+		t.Run(mode, func(t *testing.T) {
+			fakeSysfs(t, []fakeGPU{
+				{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "spx", memoryMode: mode, bus: 0x19, dev: 0},
+			})
+			_, err := enumerateAllPossibleDevices()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), mode)
+		})
+	}
+}
+
+// A GPU with no partitioning support reports neither mode, and an empty memory mode is the
+// kernel saying so rather than a value to validate. It must still be published.
+func TestEnumeratePublishesGPUWithoutPartitionSupport(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)()
+	fakeSysfs(t, []fakeGPU{
+		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "", memoryMode: "", bus: 0x19, dev: 0},
+	})
+
+	devices, err := enumerateAllPossibleDevices()
+	require.NoError(t, err)
+	require.Len(t, devices, 1, "a GPU that does not support partitioning must still be published")
+}
+
 // The amdgpu sysfs root disappearing during a driver reload must stay retryable instead
 // of reading as a completed discovery that happens to have found nothing.
 func TestEnumerateDoesNotAcceptAVanishedDriverRoot(t *testing.T) {

--- a/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_sysfs_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ROCm/k8s-gpu-dra-driver/pkg/amdgpu"
 	"github.com/stretchr/testify/require"
@@ -139,6 +140,7 @@ func TestEnumerateAttachesPartitionsToPhysicalParent(t *testing.T) {
 // the previous GPU's card, render, or kfd identity. This is the carry-over this PR
 // removes, checked through discovery rather than the helper alone.
 func TestEnumerateSkipsIncompleteIdentityWithoutBorrowing(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)() // the device stays incomplete; no need to wait out the backoff
 	fakeSysfs(t, []fakeGPU{
 		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "spx", memoryMode: "nps1", bus: 0x19, dev: 0},
 	})
@@ -177,6 +179,7 @@ func TestEnumerateRejectsUnknownPartitionMode(t *testing.T) {
 // An unreadable partition file must not read as "no partitioning support": that would
 // publish a partitioned GPU as one whole allocatable device.
 func TestEnumerateSkipsDeviceWithUnreadablePartitionFile(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)() // the device stays incomplete; no need to wait out the backoff
 	fakeSysfs(t, []fakeGPU{
 		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "cpx", memoryMode: "nps1", bus: 0x19, dev: 0},
 	})
@@ -194,6 +197,7 @@ func TestEnumerateSkipsDeviceWithUnreadablePartitionFile(t *testing.T) {
 // its partitions are skipped for the same missing id, so it would advertise part of a
 // partitioned GPU as if it were the whole topology.
 func TestEnumerateSkipsPartitionedGPUWithoutKFDIdentity(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)() // the identity never appears in this test
 	for _, mode := range []string{"dpx", "tpx"} {
 		t.Run(mode, func(t *testing.T) {
 			fakeSysfs(t, []fakeGPU{
@@ -207,4 +211,41 @@ func TestEnumerateSkipsPartitionedGPUWithoutKFDIdentity(t *testing.T) {
 			require.Empty(t, devices, "no partial topology may be published for %s", mode)
 		})
 	}
+}
+
+// A GPU bound to amdgpu whose DRM entries appear a moment after the plugin starts must
+// end up published. Discovery runs once, so without a retry it would stay missing until
+// the process restarts even though the hardware is fine.
+func TestEnumerateRetriesUntilDRMEntriesAppear(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(20, 20*time.Millisecond)()
+	fakeSysfs(t, []fakeGPU{
+		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "spx", memoryMode: "nps1", bus: 0x19, dev: 0},
+	})
+
+	// Take the drm entries away, then put them back while discovery is retrying.
+	drm := filepath.Join(amdgpu.AMDGPUDriversPath, "pci:amdgpu", "0000:19:00.0", "drm")
+	require.NoError(t, os.RemoveAll(drm))
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = os.MkdirAll(filepath.Join(drm, "card0"), 0o755)
+		_ = os.MkdirAll(filepath.Join(drm, "renderD128"), 0o755)
+	}()
+
+	devices, err := enumerateAllPossibleDevices()
+	require.NoError(t, err)
+	require.Contains(t, devices, "gpu-0-128", "the GPU must be published once its entries appear")
+}
+
+// Without the retry the same GPU is lost, which is what makes the retry load-bearing
+// rather than a delay that happens to be harmless.
+func TestEnumerateWithoutRetryLosesLateDRMEntries(t *testing.T) {
+	defer amdgpu.SetDiscoveryRetry(1, 0)()
+	fakeSysfs(t, []fakeGPU{
+		{pciAddr: "0000:19:00.0", card: 0, render: 128, computeMode: "spx", memoryMode: "nps1", bus: 0x19, dev: 0},
+	})
+	require.NoError(t, os.RemoveAll(filepath.Join(amdgpu.AMDGPUDriversPath, "pci:amdgpu", "0000:19:00.0", "drm")))
+
+	devices, err := enumerateAllPossibleDevices()
+	require.NoError(t, err)
+	require.Empty(t, devices, "a single attempt cannot see entries that appear later")
 }

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -34,7 +34,7 @@ import (
 
 // GetDriverVersion reads the AMDGPU driver version
 func GetDriverVersion() string {
-	matches, _ := filepath.Glob("/sys/class/drm/card*/device/driver/module/version")
+	matches, _ := filepath.Glob(filepath.Join(DRMClassPath, "card*/device/driver/module/version"))
 	if len(matches) == 0 {
 		glog.Warningf("No AMD GPU cards found for driver version reading; driverVersion attribute will be omitted")
 		return ""
@@ -134,13 +134,13 @@ func resolveDRMIdentity(devPaths []string, topologyInfo map[int]*TopologyInfo) (
 
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address
 func GetAMDGPUs() map[string]map[string]interface{} {
-	if _, err := os.Stat("/sys/module/amdgpu/drivers/"); err != nil {
+	if _, err := os.Stat(AMDGPUDriversPath); err != nil {
 		glog.Warningf("amdgpu driver unavailable: %s", err)
 		return make(map[string]map[string]interface{})
 	}
 
 	//ex: /sys/module/amdgpu/drivers/pci:amdgpu/0000:19:00.0
-	matches, _ := filepath.Glob("/sys/module/amdgpu/drivers/pci:amdgpu/[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]:*")
+	matches, _ := filepath.Glob(filepath.Join(AMDGPUDriversPath, "pci:amdgpu/[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]:*"))
 
 	devices := make(map[string]map[string]interface{})
 
@@ -200,7 +200,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 
 		// Get product name
 		productName := ""
-		productNamePath := fmt.Sprintf("/sys/class/drm/card%d/device/product_name", card)
+		productNamePath := filepath.Join(DRMClassPath, fmt.Sprintf("card%d/device/product_name", card))
 		if b, err := os.ReadFile(productNamePath); err != nil {
 			glog.Warningf("Failed to read product name from %s: %s", productNamePath, err)
 		} else {
@@ -243,7 +243,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 
 	// certain products have additional devices (such as MI300's partitions)
 	//ex: /sys/devices/platform/amdgpu_xcp_30
-	platformMatches, _ := filepath.Glob("/sys/devices/platform/amdgpu_xcp_*")
+	platformMatches, _ := filepath.Glob(filepath.Join(PlatformDevicesPath, "amdgpu_xcp_*"))
 
 	for _, path := range platformMatches {
 		glog.Info(path)
@@ -316,7 +316,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 // GetDeviceID reads the PCI device ID from sysfs for the given DRM card
 // Returns the device ID string (e.g., "0x740f") or empty string on failure
 func GetDeviceID(cardName string) string {
-	sysfsDevicePath := "/sys/class/drm/" + cardName + "/device/device"
+	sysfsDevicePath := filepath.Join(DRMClassPath, cardName, "device/device")
 	b, err := os.ReadFile(sysfsDevicePath)
 	if err != nil {
 		glog.Warningf("Failed to read device ID from %s: %s", sysfsDevicePath, err)
@@ -327,7 +327,7 @@ func GetDeviceID(cardName string) string {
 
 // AMDGPU check if a particular card is an AMD GPU by checking the device's vendor ID
 func AMDGPU(cardName string) bool {
-	sysfsVendorPath := "/sys/class/drm/" + cardName + "/device/vendor"
+	sysfsVendorPath := filepath.Join(DRMClassPath, cardName, "device/vendor")
 	b, err := os.ReadFile(sysfsVendorPath)
 	if err == nil {
 		vid := strings.TrimSpace(string(b))
@@ -416,7 +416,7 @@ var topoDomainRe = regexp.MustCompile(`domain\s(\d+)`)
 // GetTopologyInfo returns comprehensive topology information for all render devices
 // This combines the functionality of GetDevIdsFromTopology and GetNodeIdsFromTopology
 func GetTopologyInfo(topoRootParam ...string) map[int]*TopologyInfo {
-	topoRoot := "/sys/class/kfd/kfd"
+	topoRoot := KFDTopologyPath
 	if len(topoRootParam) == 1 {
 		topoRoot = topoRootParam[0]
 	}

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -194,29 +194,75 @@ func SetDiscoveryRetry(attempts int, backoff time.Duration) (restore func()) {
 	return func() { discoveryAttempts, discoveryBackoff = prevAttempts, prevBackoff }
 }
 
+// readStablePartitionPair returns the two partition modes only if they held still while
+// being read. They come from separate files, so a repartition in between yields a pair
+// that never existed on the hardware, such as spx from before the change with nps4 from
+// after it. read is a parameter so a test can change a mode between the two passes.
+func readStablePartitionPair(read func(string) (string, error), computeFile, memoryFile string) (string, string, error) {
+	compute, err := read(computeFile)
+	if err != nil {
+		return "", "", err
+	}
+	memory, err := read(memoryFile)
+	if err != nil {
+		return "", "", err
+	}
+
+	recheckCompute, err := read(computeFile)
+	if err != nil {
+		return "", "", err
+	}
+	recheckMemory, err := read(memoryFile)
+	if err != nil {
+		return "", "", err
+	}
+	if recheckCompute != compute || recheckMemory != memory {
+		return "", "", fmt.Errorf("partition mode changed during discovery (compute %q->%q, memory %q->%q)",
+			compute, recheckCompute, memory, recheckMemory)
+	}
+	return compute, memory, nil
+}
+
+// discoveryFingerprint identifies which devices a pass found rather than how many. Two
+// passes can report the same count with one GPU replaced by another, or with the same
+// GPUs under different card, render or partition mappings.
+func discoveryFingerprint(devices map[string]map[string]interface{}) string {
+	names := make([]string, 0, len(devices))
+	for name := range devices {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, name := range names {
+		d := devices[name]
+		fmt.Fprintf(&b, "%s|%v|%v|%v|%v|%v|%v|%v;", name, d["pciAddr"], d["card"], d["renderD"],
+			d["kfdID"], d["nodeId"], d["computePartitionType"], d["memoryPartitionType"])
+	}
+	return b.String()
+}
+
 // GetAMDGPUs returns the AMD GPUs on the node, keyed by part of the PCI address. A device
 // bound to amdgpu whose DRM or KFD entries have not appeared yet is retried a few times,
 // since discovery runs once and would otherwise leave the GPU missing for the lifetime of
-// the process. A device still incomplete after that is skipped as before.
+// the process. Publishing waits for two consecutive passes that skip nothing and describe
+// the same devices, which costs one backoff at startup and is what rules out a pass taken
+// across a driver reload or a repartition. A pass still unsettled after that is published
+// as before, since a plugin that never starts is worse than one that starts incomplete.
 func GetAMDGPUs() map[string]map[string]interface{} {
-	seen := 0
+	previous, havePrevious := "", false
 	for attempt := 1; ; attempt++ {
 		devices, skipped := discoverAMDGPUs()
-		// Fewer devices than a previous attempt saw means the tree changed underneath
-		// this pass, so it is no more complete than the one that skipped something.
-		if len(devices) < seen {
-			glog.Warningf("discovery saw %d device(s) after a previous attempt saw %d; treating the pass as incomplete", len(devices), seen)
-			skipped++
-		}
-		seen = max(seen, len(devices))
-		if skipped == 0 {
+		current := discoveryFingerprint(devices)
+		if skipped == 0 && havePrevious && current == previous {
 			return devices
 		}
+		previous, havePrevious = current, true
 		if attempt >= discoveryAttempts {
-			glog.Warningf("%d device(s) still had incomplete sysfs entries after %d attempts; they are not published until the plugin restarts", skipped, attempt)
+			glog.Warningf("discovery had not settled after %d attempts (%d device(s) incomplete); publishing %d device(s) until the plugin restarts", attempt, skipped, len(devices))
 			return devices
 		}
-		glog.Infof("%d device(s) have incomplete sysfs entries; retrying discovery (%d/%d)", skipped, attempt, discoveryAttempts)
+		glog.Infof("discovery not settled (%d device(s) incomplete); retrying (%d/%d)", skipped, attempt, discoveryAttempts)
 		time.Sleep(discoveryBackoff)
 	}
 }
@@ -250,16 +296,7 @@ func discoverAMDGPUs() (map[string]map[string]interface{}, int) {
 
 		var numaNode int
 
-		// Read the compute partition
-		computePartitionType, err := readPartitionMode(computePartitionFile)
-		if err != nil {
-			glog.Errorf("Skipping device %s: %s", pciAddrOf(path), err)
-			skipped++
-			continue
-		}
-
-		// Read the memory partition
-		memoryPartitionType, err := readPartitionMode(memoryPartitionFile)
+		computePartitionType, memoryPartitionType, err := readStablePartitionPair(readPartitionMode, computePartitionFile, memoryPartitionFile)
 		if err != nil {
 			glog.Errorf("Skipping device %s: %s", pciAddrOf(path), err)
 			skipped++

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -71,26 +71,64 @@ func SemverDriverVersion(version string) string {
 	return strings.Join(parts[:3], ".")
 }
 
-// resolveDRMIdentity reads a single GPU's card index, render minor, KFD node ID,
-// and unique (kfd) ID from its drm entries. It starts from fresh defaults on every
-// call, so a device with missing drm entries or no topology match reports its own
-// defaults instead of inheriting the previous device's identity.
-func resolveDRMIdentity(devPaths []string, topologyInfo map[int]*TopologyInfo) (card, renderD, nodeId int, devID string) {
-	card, renderD, nodeId, devID = 0, 128, 0, ""
+// parseDRMIndex returns the numeric index of a DRM node name (for example 128
+// from "renderD128"). ok is false when the prefix is missing or the suffix is
+// not a plain decimal, so a malformed name is skipped instead of read as index 0.
+func parseDRMIndex(name, prefix string) (int, bool) {
+	suffix, found := strings.CutPrefix(name, prefix)
+	if !found || suffix == "" {
+		return 0, false
+	}
+	for _, r := range suffix {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// resolveDRMIdentity reads a GPU's card index, render minor, KFD node ID, and
+// unique (kfd) ID from its drm entries, starting fresh on every call so a device
+// never inherits the previous one's identity. ok is true only when both a card
+// and a render node resolve to a valid index; otherwise the caller skips the
+// device instead of publishing it with a borrowed or default identity.
+func resolveDRMIdentity(devPaths []string, topologyInfo map[int]*TopologyInfo) (card, renderD, nodeId int, devID string, ok bool) {
+	haveCard, haveRender, conflict := false, false, false
 	for _, devPath := range devPaths {
 		name := filepath.Base(devPath)
 		switch {
 		case strings.HasPrefix(name, "card"):
-			card, _ = strconv.Atoi(name[len("card"):])
+			n, valid := parseDRMIndex(name, "card")
+			if !valid {
+				continue
+			}
+			if haveCard && n != card {
+				conflict = true
+			}
+			card, haveCard = n, true
 		case strings.HasPrefix(name, "renderD"):
-			renderD, _ = strconv.Atoi(name[len("renderD"):])
-			if info, exists := topologyInfo[renderD]; exists {
-				devID = info.UniqueID
-				nodeId = info.NodeID
+			n, valid := parseDRMIndex(name, "renderD")
+			if !valid {
+				continue
+			}
+			if haveRender && n != renderD {
+				conflict = true
+			}
+			renderD, haveRender = n, true
+			// Keep nodeId/devID tied to the current renderD; a render node without
+			// topology contributes no identity rather than a previous one's.
+			if info, exists := topologyInfo[n]; exists {
+				devID, nodeId = info.UniqueID, info.NodeID
+			} else {
+				devID, nodeId = "", 0
 			}
 		}
 	}
-	return
+	return card, renderD, nodeId, devID, haveCard && haveRender && !conflict
 }
 
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address
@@ -147,9 +185,13 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 
 		glog.Info(path)
 		devPaths, _ := filepath.Glob(path + "/drm/*")
-		card, renderD, nodeId, devID := resolveDRMIdentity(devPaths, topologyInfo)
 		// Extract PCI address from path (e.g., "0000:19:00.0" from "/sys/module/amdgpu/drivers/pci:amdgpu/0000:19:00.0")
 		pciAddr := filepath.Base(path)
+		card, renderD, nodeId, devID, ok := resolveDRMIdentity(devPaths, topologyInfo)
+		if !ok {
+			glog.Warningf("Skipping device %s: no valid card and renderD drm entries", pciAddr)
+			continue
+		}
 
 		// Get product name
 		productName := ""
@@ -203,7 +245,11 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		productName := ""
 		sysfsDeviceID := ""
 
-		card, renderD, nodeId, devID := resolveDRMIdentity(devPaths, topologyInfo)
+		card, renderD, nodeId, devID, ok := resolveDRMIdentity(devPaths, topologyInfo)
+		if !ok || devID == "" {
+			glog.Warningf("Skipping platform device %s: unresolved GPU identity", filepath.Base(path))
+			continue
+		}
 		// Inherit the compute/memory partition, NUMA node, PCI address, product name,
 		// and device ID from the parent GPU that shares this kfd (unique) ID.
 		for _, device := range devices {

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -71,6 +71,28 @@ func SemverDriverVersion(version string) string {
 	return strings.Join(parts[:3], ".")
 }
 
+// resolveDRMIdentity reads a single GPU's card index, render minor, KFD node ID,
+// and unique (kfd) ID from its drm entries. It starts from fresh defaults on every
+// call, so a device with missing drm entries or no topology match reports its own
+// defaults instead of inheriting the previous device's identity.
+func resolveDRMIdentity(devPaths []string, topologyInfo map[int]*TopologyInfo) (card, renderD, nodeId int, devID string) {
+	card, renderD, nodeId, devID = 0, 128, 0, ""
+	for _, devPath := range devPaths {
+		name := filepath.Base(devPath)
+		switch {
+		case strings.HasPrefix(name, "card"):
+			card, _ = strconv.Atoi(name[len("card"):])
+		case strings.HasPrefix(name, "renderD"):
+			renderD, _ = strconv.Atoi(name[len("renderD"):])
+			if info, exists := topologyInfo[renderD]; exists {
+				devID = info.UniqueID
+				nodeId = info.NodeID
+			}
+		}
+	}
+	return
+}
+
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address
 func GetAMDGPUs() map[string]map[string]interface{} {
 	if _, err := os.Stat("/sys/module/amdgpu/drivers/"); err != nil {
@@ -81,9 +103,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 	//ex: /sys/module/amdgpu/drivers/pci:amdgpu/0000:19:00.0
 	matches, _ := filepath.Glob("/sys/module/amdgpu/drivers/pci:amdgpu/[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]:*")
 
-	devID := ""
 	devices := make(map[string]map[string]interface{})
-	card, renderD, nodeId := 0, 128, 0
 
 	// Get comprehensive topology information once instead of multiple calls
 	topologyInfo := GetTopologyInfo()
@@ -127,20 +147,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 
 		glog.Info(path)
 		devPaths, _ := filepath.Glob(path + "/drm/*")
-
-		for _, devPath := range devPaths {
-			switch name := filepath.Base(devPath); {
-			case name[0:4] == "card":
-				card, _ = strconv.Atoi(name[4:])
-			case name[0:7] == "renderD":
-				renderD, _ = strconv.Atoi(name[7:])
-				if info, exists := topologyInfo[renderD]; exists {
-					devID = info.UniqueID
-					nodeId = info.NodeID
-				}
-			}
-
-		}
+		card, renderD, nodeId, devID := resolveDRMIdentity(devPaths, topologyInfo)
 		// Extract PCI address from path (e.g., "0000:19:00.0" from "/sys/module/amdgpu/drivers/pci:amdgpu/0000:19:00.0")
 		pciAddr := filepath.Base(path)
 
@@ -196,29 +203,19 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		productName := ""
 		sysfsDeviceID := ""
 
-		for _, devPath := range devPaths {
-			switch name := filepath.Base(devPath); {
-			case name[0:4] == "card":
-				card, _ = strconv.Atoi(name[4:])
-			case name[0:7] == "renderD":
-				renderD, _ = strconv.Atoi(name[7:])
-				if info, exists := topologyInfo[renderD]; exists {
-					devID = info.UniqueID
-					nodeId = info.NodeID
-				}
-				// Set the computePartitionType, memoryPartitionType, numaNode, PCI address from the real GPU using the common devID
-				for _, device := range devices {
-					if device["kfdID"] == devID {
-						parentPciAddr = device["pciAddr"].(string)
-						numaNode = device["numaNode"].(int)
-						productName = device["productName"].(string)
-						sysfsDeviceID = device["deviceID"].(string)
-						if device["computePartitionType"].(string) != "" && device["memoryPartitionType"].(string) != "" {
-							computePartitionType = device["computePartitionType"].(string)
-							memoryPartitionType = device["memoryPartitionType"].(string)
-							break
-						}
-					}
+		card, renderD, nodeId, devID := resolveDRMIdentity(devPaths, topologyInfo)
+		// Inherit the compute/memory partition, NUMA node, PCI address, product name,
+		// and device ID from the parent GPU that shares this kfd (unique) ID.
+		for _, device := range devices {
+			if device["kfdID"] == devID {
+				parentPciAddr = device["pciAddr"].(string)
+				numaNode = device["numaNode"].(int)
+				productName = device["productName"].(string)
+				sysfsDeviceID = device["deviceID"].(string)
+				if device["computePartitionType"].(string) != "" && device["memoryPartitionType"].(string) != "" {
+					computePartitionType = device["computePartitionType"].(string)
+					memoryPartitionType = device["memoryPartitionType"].(string)
+					break
 				}
 			}
 		}

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -192,6 +192,12 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 			glog.Warningf("Skipping device %s: no valid card and renderD drm entries", pciAddr)
 			continue
 		}
+		if devID == "" {
+			// A full GPU with card/render but no KFD topology has no compute identity.
+			// The platform-partition path skips this state; the physical path still
+			// publishes it, so surface it rather than hiding a possibly non-usable GPU.
+			glog.Warningf("device %s (card%d renderD%d) has no KFD topology; publishing it as a full GPU with no compute identity", pciAddr, card, renderD)
+		}
 
 		// Get product name
 		productName := ""

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 )
@@ -177,17 +178,54 @@ func readPartitionMode(path string) (string, error) {
 	return strings.ToLower(strings.TrimSpace(string(data))), nil
 }
 
-// GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address
+// discoveryAttempts and discoveryBackoff bound the wait for a GPU whose sysfs entries are
+// still appearing. Discovery runs once at startup, so a device skipped here stays missing
+// until the plugin restarts.
+var (
+	discoveryAttempts = 5
+	discoveryBackoff  = 200 * time.Millisecond
+)
+
+// SetDiscoveryRetry overrides the retry bounds. Used by tests to avoid waiting out the
+// real backoff for a device that is meant to stay incomplete.
+func SetDiscoveryRetry(attempts int, backoff time.Duration) (restore func()) {
+	prevAttempts, prevBackoff := discoveryAttempts, discoveryBackoff
+	discoveryAttempts, discoveryBackoff = attempts, backoff
+	return func() { discoveryAttempts, discoveryBackoff = prevAttempts, prevBackoff }
+}
+
+// GetAMDGPUs returns the AMD GPUs on the node, keyed by part of the PCI address. A device
+// bound to amdgpu whose DRM or KFD entries have not appeared yet is retried a few times,
+// since discovery runs once and would otherwise leave the GPU missing for the lifetime of
+// the process. A device still incomplete after that is skipped as before.
 func GetAMDGPUs() map[string]map[string]interface{} {
+	for attempt := 1; ; attempt++ {
+		devices, skipped := discoverAMDGPUs()
+		if skipped == 0 {
+			return devices
+		}
+		if attempt >= discoveryAttempts {
+			glog.Warningf("%d device(s) still had incomplete sysfs entries after %d attempts; they are not published until the plugin restarts", skipped, attempt)
+			return devices
+		}
+		glog.Infof("%d device(s) have incomplete sysfs entries; retrying discovery (%d/%d)", skipped, attempt, discoveryAttempts)
+		time.Sleep(discoveryBackoff)
+	}
+}
+
+// discoverAMDGPUs runs one discovery pass, returning the devices it published and how many
+// it skipped for a condition that may still resolve.
+func discoverAMDGPUs() (map[string]map[string]interface{}, int) {
 	if _, err := os.Stat(AMDGPUDriversPath); err != nil {
 		glog.Warningf("amdgpu driver unavailable: %s", err)
-		return make(map[string]map[string]interface{})
+		return make(map[string]map[string]interface{}), 0
 	}
 
 	//ex: /sys/module/amdgpu/drivers/pci:amdgpu/0000:19:00.0
 	matches, _ := filepath.Glob(filepath.Join(AMDGPUDriversPath, "pci:amdgpu/[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]:*"))
 
 	devices := make(map[string]map[string]interface{})
+	skipped := 0
 
 	// Get comprehensive topology information once instead of multiple calls
 	topologyInfo := GetTopologyInfo()
@@ -206,6 +244,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		computePartitionType, err := readPartitionMode(computePartitionFile)
 		if err != nil {
 			glog.Errorf("Skipping device %s: %s", pciAddrOf(path), err)
+			skipped++
 			continue
 		}
 
@@ -213,6 +252,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		memoryPartitionType, err := readPartitionMode(memoryPartitionFile)
 		if err != nil {
 			glog.Errorf("Skipping device %s: %s", pciAddrOf(path), err)
+			skipped++
 			continue
 		}
 
@@ -221,10 +261,12 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 			numaNode, err = strconv.Atoi(numaNodeStr)
 			if err != nil {
 				glog.Warningf("Failed to convert 'numa_node' value to int: %s", err)
+				skipped++
 				continue
 			}
 		} else {
 			glog.Warningf("Failed to read 'numa_node' file at %s: %s", numaNodeFile, err)
+			skipped++
 			continue
 		}
 
@@ -235,6 +277,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		card, renderD, nodeId, devID, ok := resolveDRMIdentity(devPaths, topologyInfo)
 		if !ok {
 			glog.Warningf("Skipping device %s: no valid card and renderD drm entries", pciAddr)
+			skipped++
 			continue
 		}
 		if devID == "" {
@@ -244,6 +287,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 			// usable whole, so only the partitioned case is dropped.
 			if computePartitionType != "" && computePartitionType != "spx" {
 				glog.Warningf("Skipping device %s (card%d renderD%d): compute mode %q but no KFD compute identity yet, so its partitions cannot be matched", pciAddr, card, renderD, computePartitionType)
+				skipped++
 				continue
 			}
 			glog.Warningf("device %s (card%d renderD%d) has no KFD compute identity (empty unique id); publishing it as a full GPU anyway", pciAddr, card, renderD)
@@ -309,6 +353,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		card, renderD, nodeId, devID, ok := resolveDRMIdentity(devPaths, topologyInfo)
 		if !ok || devID == "" {
 			glog.Warningf("Skipping platform device %s: unresolved GPU identity", filepath.Base(path))
+			skipped++
 			continue
 		}
 		// Inherit the compute/memory partition, NUMA node, PCI address, product name,
@@ -316,6 +361,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		parent, err := uniquePhysicalParent(devID, physicalDevices)
 		if err != nil {
 			glog.Warningf("Skipping platform device %s: %s", filepath.Base(path), err)
+			skipped++
 			continue
 		}
 		parentPciAddr = parent["pciAddr"].(string)
@@ -359,7 +405,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		devices[filepath.Base(path)] = deviceInfo
 	}
 	glog.Infof("Devices map: %v", devices)
-	return devices
+	return devices, skipped
 }
 
 // GetDeviceID reads the PCI device ID from sysfs for the given DRM card

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -22,6 +22,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -238,6 +239,11 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		devices[filepath.Base(path)] = deviceInfo
 	}
 
+	// Snapshot the physical GPUs before the platform loop starts appending to devices, so a
+	// partition matches its parent and not an XCP sibling an earlier iteration added.
+	physicalDevices := make(map[string]map[string]interface{}, len(devices))
+	maps.Copy(physicalDevices, devices)
+
 	// certain products have additional devices (such as MI300's partitions)
 	//ex: /sys/devices/platform/amdgpu_xcp_30
 	platformMatches, _ := filepath.Glob("/sys/devices/platform/amdgpu_xcp_*")
@@ -259,7 +265,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		}
 		// Inherit the compute/memory partition, NUMA node, PCI address, product name,
 		// and device ID from the parent GPU that shares this kfd (unique) ID.
-		for _, device := range devices {
+		for _, device := range physicalDevices {
 			if device["kfdID"] == devID {
 				parentPciAddr = device["pciAddr"].(string)
 				numaNode = device["numaNode"].(int)

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -194,10 +194,7 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 			continue
 		}
 		if devID == "" {
-			// An empty KFD unique id (no topology entry, or a topology entry with no
-			// unique id) means the device has no compute identity. The platform-partition
-			// path skips this state; the physical path still publishes it, so surface it
-			// rather than hiding a possibly non-usable GPU.
+			// The platform path skips this state, so surface it rather than hiding a possibly unusable GPU.
 			glog.Warningf("device %s (card%d renderD%d) has no KFD compute identity (empty unique id); publishing it as a full GPU anyway", pciAddr, card, renderD)
 		}
 
@@ -239,8 +236,8 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		devices[filepath.Base(path)] = deviceInfo
 	}
 
-	// Snapshot the physical GPUs before the platform loop starts appending to devices, so a
-	// partition matches its parent and not an XCP sibling an earlier iteration added.
+	// The platform loop appends to devices, so search a snapshot of the physical GPUs: a
+	// partition must match its parent, never an XCP sibling an earlier iteration added.
 	physicalDevices := make(map[string]map[string]interface{}, len(devices))
 	maps.Copy(physicalDevices, devices)
 

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -132,6 +133,50 @@ func resolveDRMIdentity(devPaths []string, topologyInfo map[int]*TopologyInfo) (
 	return card, renderD, nodeId, devID, haveCard && haveRender && !conflict
 }
 
+// uniquePhysicalParent returns the one physical GPU sharing devID. Zero matches means
+// the parent has not been discovered, and more than one means two GPUs reported the same
+// kfd id, so neither can be attributed. Both are errors rather than a first-match guess,
+// since map iteration order would otherwise decide which parent a partition inherits.
+func uniquePhysicalParent(devID string, physical map[string]map[string]interface{}) (map[string]interface{}, error) {
+	var found map[string]interface{}
+	var addrs []string
+	for _, device := range physical {
+		if device["kfdID"] != devID {
+			continue
+		}
+		addr, _ := device["pciAddr"].(string)
+		addrs = append(addrs, addr)
+		found = device
+	}
+	switch len(addrs) {
+	case 0:
+		return nil, fmt.Errorf("no physical GPU reports kfd id %q", devID)
+	case 1:
+		return found, nil
+	default:
+		sort.Strings(addrs)
+		return nil, fmt.Errorf("kfd id %q is reported by %d physical GPUs (%s)", devID, len(addrs), strings.Join(addrs, ", "))
+	}
+}
+
+// pciAddrOf returns the PCI address encoded in a sysfs device path.
+func pciAddrOf(devicePath string) string { return filepath.Base(devicePath) }
+
+// readPartitionMode reads a current_*_partition file. A missing file means the device
+// does not support partitioning, which is a whole GPU. Any other error is returned
+// rather than reported as an empty mode, because an empty mode reads downstream as
+// "no partitioning" and would publish a partitioned GPU as one whole device.
+func readPartitionMode(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("unable to read %s: %w", path, err)
+	}
+	return strings.ToLower(strings.TrimSpace(string(data))), nil
+}
+
 // GetAMDGPUs return a map of AMD GPU on a node identified by the part of the pci address
 func GetAMDGPUs() map[string]map[string]interface{} {
 	if _, err := os.Stat(AMDGPUDriversPath); err != nil {
@@ -155,21 +200,20 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		memoryPartitionFile := filepath.Join(path, "current_memory_partition")
 		numaNodeFile := filepath.Join(path, "numa_node")
 
-		computePartitionType, memoryPartitionType := "", ""
 		var numaNode int
 
 		// Read the compute partition
-		if data, err := os.ReadFile(computePartitionFile); err == nil {
-			computePartitionType = strings.ToLower(strings.TrimSpace(string(data)))
-		} else {
-			glog.Warningf("Failed to read 'current_compute_partition' file at %s: %s", computePartitionFile, err)
+		computePartitionType, err := readPartitionMode(computePartitionFile)
+		if err != nil {
+			glog.Errorf("Skipping device %s: %s", pciAddrOf(path), err)
+			continue
 		}
 
 		// Read the memory partition
-		if data, err := os.ReadFile(memoryPartitionFile); err == nil {
-			memoryPartitionType = strings.ToLower(strings.TrimSpace(string(data)))
-		} else {
-			glog.Warningf("Failed to read 'current_memory_partition' file at %s: %s", memoryPartitionFile, err)
+		memoryPartitionType, err := readPartitionMode(memoryPartitionFile)
+		if err != nil {
+			glog.Errorf("Skipping device %s: %s", pciAddrOf(path), err)
+			continue
 		}
 
 		if data, err := os.ReadFile(numaNodeFile); err == nil {
@@ -194,7 +238,14 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 			continue
 		}
 		if devID == "" {
-			// The platform path skips this state, so surface it rather than hiding a possibly unusable GPU.
+			// Partitions find their parent by this id, and the platform loop skips a
+			// partition without one, so publishing this device alone would advertise
+			// part of a partitioned GPU. A device that is not partitioned is still
+			// usable whole, so only the partitioned case is dropped.
+			if computePartitionType != "" && computePartitionType != "spx" {
+				glog.Warningf("Skipping device %s (card%d renderD%d): compute mode %q but no KFD compute identity yet, so its partitions cannot be matched", pciAddr, card, renderD, computePartitionType)
+				continue
+			}
 			glog.Warningf("device %s (card%d renderD%d) has no KFD compute identity (empty unique id); publishing it as a full GPU anyway", pciAddr, card, renderD)
 		}
 
@@ -262,19 +313,17 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 		}
 		// Inherit the compute/memory partition, NUMA node, PCI address, product name,
 		// and device ID from the parent GPU that shares this kfd (unique) ID.
-		for _, device := range physicalDevices {
-			if device["kfdID"] == devID {
-				parentPciAddr = device["pciAddr"].(string)
-				numaNode = device["numaNode"].(int)
-				productName = device["productName"].(string)
-				sysfsDeviceID = device["deviceID"].(string)
-				if device["computePartitionType"].(string) != "" && device["memoryPartitionType"].(string) != "" {
-					computePartitionType = device["computePartitionType"].(string)
-					memoryPartitionType = device["memoryPartitionType"].(string)
-					break
-				}
-			}
+		parent, err := uniquePhysicalParent(devID, physicalDevices)
+		if err != nil {
+			glog.Warningf("Skipping platform device %s: %s", filepath.Base(path), err)
+			continue
 		}
+		parentPciAddr = parent["pciAddr"].(string)
+		numaNode = parent["numaNode"].(int)
+		productName = parent["productName"].(string)
+		sysfsDeviceID = parent["deviceID"].(string)
+		computePartitionType = parent["computePartitionType"].(string)
+		memoryPartitionType = parent["memoryPartitionType"].(string)
 		// This is needed because some of the visible renderD are actually not valid
 		// Their validity depends on topology information from KFD
 

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -199,8 +199,16 @@ func SetDiscoveryRetry(attempts int, backoff time.Duration) (restore func()) {
 // since discovery runs once and would otherwise leave the GPU missing for the lifetime of
 // the process. A device still incomplete after that is skipped as before.
 func GetAMDGPUs() map[string]map[string]interface{} {
+	seen := 0
 	for attempt := 1; ; attempt++ {
 		devices, skipped := discoverAMDGPUs()
+		// Fewer devices than a previous attempt saw means the tree changed underneath
+		// this pass, so it is no more complete than the one that skipped something.
+		if len(devices) < seen {
+			glog.Warningf("discovery saw %d device(s) after a previous attempt saw %d; treating the pass as incomplete", len(devices), seen)
+			skipped++
+		}
+		seen = max(seen, len(devices))
 		if skipped == 0 {
 			return devices
 		}
@@ -217,8 +225,10 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 // it skipped for a condition that may still resolve.
 func discoverAMDGPUs() (map[string]map[string]interface{}, int) {
 	if _, err := os.Stat(AMDGPUDriversPath); err != nil {
+		// Retryable: the module may be reloading. On a node with no AMD GPU at all
+		// this costs one bounded backoff at startup and still returns empty.
 		glog.Warningf("amdgpu driver unavailable: %s", err)
-		return make(map[string]map[string]interface{}), 0
+		return make(map[string]map[string]interface{}), 1
 	}
 
 	//ex: /sys/module/amdgpu/drivers/pci:amdgpu/0000:19:00.0
@@ -252,6 +262,15 @@ func discoverAMDGPUs() (map[string]map[string]interface{}, int) {
 		memoryPartitionType, err := readPartitionMode(memoryPartitionFile)
 		if err != nil {
 			glog.Errorf("Skipping device %s: %s", pciAddrOf(path), err)
+			skipped++
+			continue
+		}
+
+		// The two files appear and disappear together on a partitioned GPU. Exactly one
+		// of them means the read caught the tree mid-change, and reading it as "no
+		// partitioning" would publish a partitioned GPU whole.
+		if (computePartitionType == "") != (memoryPartitionType == "") {
+			glog.Warningf("Skipping device %s: compute partition %q and memory partition %q are not both present", pciAddrOf(path), computePartitionType, memoryPartitionType)
 			skipped++
 			continue
 		}

--- a/pkg/amdgpu/amdgpu.go
+++ b/pkg/amdgpu/amdgpu.go
@@ -193,10 +193,11 @@ func GetAMDGPUs() map[string]map[string]interface{} {
 			continue
 		}
 		if devID == "" {
-			// A full GPU with card/render but no KFD topology has no compute identity.
-			// The platform-partition path skips this state; the physical path still
-			// publishes it, so surface it rather than hiding a possibly non-usable GPU.
-			glog.Warningf("device %s (card%d renderD%d) has no KFD topology; publishing it as a full GPU with no compute identity", pciAddr, card, renderD)
+			// An empty KFD unique id (no topology entry, or a topology entry with no
+			// unique id) means the device has no compute identity. The platform-partition
+			// path skips this state; the physical path still publishes it, so surface it
+			// rather than hiding a possibly non-usable GPU.
+			glog.Warningf("device %s (card%d renderD%d) has no KFD compute identity (empty unique id); publishing it as a full GPU anyway", pciAddr, card, renderD)
 		}
 
 		// Get product name

--- a/pkg/amdgpu/amdgpu_test.go
+++ b/pkg/amdgpu/amdgpu_test.go
@@ -49,22 +49,28 @@ func TestResolveDRMIdentity(t *testing.T) {
 		devPaths                       []string
 		wantCard, wantRender, wantNode int
 		wantDevID                      string
+		wantOK                         bool
 	}{
-		{"complete device", []string{"/d/card0", "/d/renderD128"}, 0, 128, 2, "gpu-A"},
-		{"another complete device", []string{"/d/card1", "/d/renderD129"}, 1, 129, 3, "gpu-B"},
-		// The following must return fresh defaults rather than a previous device's identity.
-		{"no drm entries", nil, 0, 128, 0, ""},
-		{"renderD without topology", []string{"/d/card4", "/d/renderD200"}, 4, 200, 0, ""},
-		{"card entry only", []string{"/d/card7"}, 7, 128, 0, ""},
-		// A short or unrelated entry is ignored instead of panicking on a name slice.
-		{"short entry ignored", []string{"/d/x"}, 0, 128, 0, ""},
+		{"complete device", []string{"/d/card0", "/d/renderD128"}, 0, 128, 2, "gpu-A", true},
+		{"another complete device", []string{"/d/card1", "/d/renderD129"}, 1, 129, 3, "gpu-B", true},
+		{"renderD without topology is still valid", []string{"/d/card4", "/d/renderD200"}, 4, 200, 0, "", true},
+		// The rest resolve no complete identity, so ok is false and the caller
+		// skips them instead of publishing a borrowed or default device. Each runs
+		// after the complete cases above to show no state carries over.
+		{"no drm entries", nil, 0, 0, 0, "", false},
+		{"card without renderD", []string{"/d/card7"}, 7, 0, 0, "", false},
+		{"renderD without card", []string{"/d/renderD128"}, 0, 128, 2, "gpu-A", false},
+		{"malformed card suffix", []string{"/d/cardfoo", "/d/renderD128"}, 0, 128, 2, "gpu-A", false},
+		{"conflicting card entries", []string{"/d/card0", "/d/card1", "/d/renderD128"}, 1, 128, 2, "gpu-A", false},
+		{"empty renderD suffix", []string{"/d/card1", "/d/renderD"}, 1, 0, 0, "", false},
+		{"short unrelated entry", []string{"/d/x"}, 0, 0, 0, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			card, renderD, nodeId, devID := resolveDRMIdentity(tt.devPaths, topo)
-			if card != tt.wantCard || renderD != tt.wantRender || nodeId != tt.wantNode || devID != tt.wantDevID {
-				t.Fatalf("got (card=%d, renderD=%d, node=%d, devID=%q), want (card=%d, renderD=%d, node=%d, devID=%q)",
-					card, renderD, nodeId, devID, tt.wantCard, tt.wantRender, tt.wantNode, tt.wantDevID)
+			card, renderD, nodeId, devID, ok := resolveDRMIdentity(tt.devPaths, topo)
+			if card != tt.wantCard || renderD != tt.wantRender || nodeId != tt.wantNode || devID != tt.wantDevID || ok != tt.wantOK {
+				t.Fatalf("got (card=%d, renderD=%d, node=%d, devID=%q, ok=%v), want (card=%d, renderD=%d, node=%d, devID=%q, ok=%v)",
+					card, renderD, nodeId, devID, ok, tt.wantCard, tt.wantRender, tt.wantNode, tt.wantDevID, tt.wantOK)
 			}
 		})
 	}

--- a/pkg/amdgpu/amdgpu_test.go
+++ b/pkg/amdgpu/amdgpu_test.go
@@ -75,3 +75,117 @@ func TestResolveDRMIdentity(t *testing.T) {
 		})
 	}
 }
+
+// sequencedRead yields the next value for a path on each call, so a test can move a
+// partition mode between the two reads that are meant to detect exactly that.
+func sequencedRead(values map[string][]string) func(string) (string, error) {
+	calls := make(map[string]int)
+	return func(path string) (string, error) {
+		seq := values[path]
+		i := calls[path]
+		calls[path]++
+		if i >= len(seq) {
+			i = len(seq) - 1
+		}
+		return seq[i], nil
+	}
+}
+
+func TestReadStablePartitionPair(t *testing.T) {
+	const computeFile, memoryFile = "compute", "memory"
+	tests := []struct {
+		name        string
+		values      map[string][]string
+		wantCompute string
+		wantMemory  string
+		wantErr     bool
+	}{
+		{
+			name:        "held still",
+			values:      map[string][]string{computeFile: {"spx", "spx"}, memoryFile: {"nps1", "nps1"}},
+			wantCompute: "spx",
+			wantMemory:  "nps1",
+		},
+		{
+			// The MI300X case: setting NPS4 moves compute to CPX, so a pass that read
+			// compute first would otherwise publish a whole GPU that is now partitioned.
+			name:    "compute moved between the reads",
+			values:  map[string][]string{computeFile: {"spx", "cpx"}, memoryFile: {"nps4", "nps4"}},
+			wantErr: true,
+		},
+		{
+			name:    "memory moved between the reads",
+			values:  map[string][]string{computeFile: {"dpx", "dpx"}, memoryFile: {"nps1", "nps4"}},
+			wantErr: true,
+		},
+		{
+			name:   "device without partitioning reports neither mode",
+			values: map[string][]string{computeFile: {"", ""}, memoryFile: {"", ""}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compute, memory, err := readStablePartitionPair(sequencedRead(tt.values), computeFile, memoryFile)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if compute != tt.wantCompute || memory != tt.wantMemory {
+				t.Errorf("got (%q, %q), want (%q, %q)", compute, memory, tt.wantCompute, tt.wantMemory)
+			}
+		})
+	}
+}
+
+// A device count cannot show that discovery has settled: a pass can lose one GPU and gain
+// another, or return the same GPUs under changed mappings, with the count never moving.
+func TestDiscoveryFingerprintSeparatesEqualCounts(t *testing.T) {
+	device := func(pciAddr string, card, render int, kfdID, compute, memory string) map[string]map[string]interface{} {
+		return map[string]map[string]interface{}{
+			"gpu-0-128": {
+				"pciAddr": pciAddr, "card": card, "renderD": render, "kfdID": kfdID, "nodeId": 1,
+				"computePartitionType": compute, "memoryPartitionType": memory,
+			},
+		}
+	}
+	base := device("0000:19:00.0", 0, 128, "19000", "spx", "nps1")
+
+	tests := []struct {
+		name  string
+		other map[string]map[string]interface{}
+		same  bool
+	}{
+		{"identical pass", device("0000:19:00.0", 0, 128, "19000", "spx", "nps1"), true},
+		{"another GPU at the same count", device("0000:1a:00.0", 0, 128, "19000", "spx", "nps1"), false},
+		{"card and render remapped", device("0000:19:00.0", 1, 129, "19000", "spx", "nps1"), false},
+		{"different KFD identity", device("0000:19:00.0", 0, 128, "1a000", "spx", "nps1"), false},
+		{"repartitioned in place", device("0000:19:00.0", 0, 128, "19000", "cpx", "nps4"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := discoveryFingerprint(tt.other) == discoveryFingerprint(base); got != tt.same {
+				t.Errorf("fingerprints equal = %v, want %v (both passes hold one device)", got, tt.same)
+			}
+		})
+	}
+}
+
+// Map iteration order is randomised, so without sorting the fingerprint would differ from
+// itself between two passes over an unchanged node and never converge.
+func TestDiscoveryFingerprintIsOrderStable(t *testing.T) {
+	devices := make(map[string]map[string]interface{})
+	for _, name := range []string{"gpu-c", "gpu-a", "gpu-e", "gpu-b", "gpu-d"} {
+		devices[name] = map[string]interface{}{"pciAddr": name, "card": 0, "renderD": 128}
+	}
+
+	first := discoveryFingerprint(devices)
+	for i := 0; i < 100; i++ {
+		if got := discoveryFingerprint(devices); got != first {
+			t.Fatalf("fingerprint changed over an unchanged map:\n%s\n%s", first, got)
+		}
+	}
+}

--- a/pkg/amdgpu/amdgpu_test.go
+++ b/pkg/amdgpu/amdgpu_test.go
@@ -38,3 +38,34 @@ func TestSemverDriverVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveDRMIdentity(t *testing.T) {
+	topo := map[int]*TopologyInfo{
+		128: {UniqueID: "gpu-A", NodeID: 2},
+		129: {UniqueID: "gpu-B", NodeID: 3},
+	}
+	tests := []struct {
+		name                           string
+		devPaths                       []string
+		wantCard, wantRender, wantNode int
+		wantDevID                      string
+	}{
+		{"complete device", []string{"/d/card0", "/d/renderD128"}, 0, 128, 2, "gpu-A"},
+		{"another complete device", []string{"/d/card1", "/d/renderD129"}, 1, 129, 3, "gpu-B"},
+		// The following must return fresh defaults rather than a previous device's identity.
+		{"no drm entries", nil, 0, 128, 0, ""},
+		{"renderD without topology", []string{"/d/card4", "/d/renderD200"}, 4, 200, 0, ""},
+		{"card entry only", []string{"/d/card7"}, 7, 128, 0, ""},
+		// A short or unrelated entry is ignored instead of panicking on a name slice.
+		{"short entry ignored", []string{"/d/x"}, 0, 128, 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			card, renderD, nodeId, devID := resolveDRMIdentity(tt.devPaths, topo)
+			if card != tt.wantCard || renderD != tt.wantRender || nodeId != tt.wantNode || devID != tt.wantDevID {
+				t.Fatalf("got (card=%d, renderD=%d, node=%d, devID=%q), want (card=%d, renderD=%d, node=%d, devID=%q)",
+					card, renderD, nodeId, devID, tt.wantCard, tt.wantRender, tt.wantNode, tt.wantDevID)
+			}
+		})
+	}
+}

--- a/pkg/amdgpu/parent_test.go
+++ b/pkg/amdgpu/parent_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amdgpu
+
+import (
+	"strings"
+	"testing"
+)
+
+func physical(addr, kfdID string) map[string]interface{} {
+	return map[string]interface{}{"pciAddr": addr, "kfdID": kfdID}
+}
+
+// A partition may only inherit from exactly one physical parent. No match means the
+// parent was not discovered, and two means the kfd id does not identify a GPU, so
+// picking either would depend on map order.
+func TestUniquePhysicalParent(t *testing.T) {
+	one := map[string]map[string]interface{}{
+		"0000:19:00.0": physical("0000:19:00.0", "0000:19:00:0"),
+		"0000:1a:00.0": physical("0000:1a:00.0", "0000:1a:00:0"),
+	}
+	two := map[string]map[string]interface{}{
+		"0000:19:00.0": physical("0000:19:00.0", "dup"),
+		"0000:1a:00.0": physical("0000:1a:00.0", "dup"),
+	}
+
+	t.Run("exactly one", func(t *testing.T) {
+		got, err := uniquePhysicalParent("0000:19:00:0", one)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["pciAddr"] != "0000:19:00.0" {
+			t.Errorf("parent = %v, want 0000:19:00.0", got["pciAddr"])
+		}
+	})
+
+	t.Run("no parent", func(t *testing.T) {
+		if _, err := uniquePhysicalParent("0000:ff:00:0", one); err == nil {
+			t.Error("a partition with no physical parent must be an error")
+		}
+	})
+
+	t.Run("ambiguous parent names both", func(t *testing.T) {
+		_, err := uniquePhysicalParent("dup", two)
+		if err == nil {
+			t.Fatal("two GPUs with the same kfd id must be an error")
+		}
+		for _, addr := range []string{"0000:19:00.0", "0000:1a:00.0"} {
+			if !strings.Contains(err.Error(), addr) {
+				t.Errorf("error %q does not name %s", err, addr)
+			}
+		}
+	})
+}

--- a/pkg/amdgpu/vfio.go
+++ b/pkg/amdgpu/vfio.go
@@ -35,6 +35,12 @@ var (
 	KernelIOMMUGroupPath = "/sys/kernel/iommu_groups"
 	VFIOModulePath       = "/sys/module/vfio_pci"
 	VFIODevicesRoot      = "/dev/vfio"
+
+	// Roots used by GPU discovery, kept here so one call rebases every sysfs path.
+	AMDGPUDriversPath   = "/sys/module/amdgpu/drivers"
+	DRMClassPath        = "/sys/class/drm"
+	PlatformDevicesPath = "/sys/devices/platform"
+	KFDTopologyPath     = "/sys/class/kfd/kfd"
 )
 
 // SetSysfsRoot rebases all sysfs/devfs path variables under the given root.
@@ -48,6 +54,10 @@ func SetSysfsRoot(root string) {
 	KernelIOMMUGroupPath = filepath.Join(root, "sys/kernel/iommu_groups")
 	VFIOModulePath = filepath.Join(root, "sys/module/vfio_pci")
 	VFIODevicesRoot = filepath.Join(root, "dev/vfio")
+	AMDGPUDriversPath = filepath.Join(root, "sys/module/amdgpu/drivers")
+	DRMClassPath = filepath.Join(root, "sys/class/drm")
+	PlatformDevicesPath = filepath.Join(root, "sys/devices/platform")
+	KFDTopologyPath = filepath.Join(root, "sys/class/kfd/kfd")
 }
 
 // ResetSysfsRoot restores all path variables to their real system defaults.
@@ -60,6 +70,10 @@ func ResetSysfsRoot() {
 	KernelIOMMUGroupPath = "/sys/kernel/iommu_groups"
 	VFIOModulePath = "/sys/module/vfio_pci"
 	VFIODevicesRoot = "/dev/vfio"
+	AMDGPUDriversPath = "/sys/module/amdgpu/drivers"
+	DRMClassPath = "/sys/class/drm"
+	PlatformDevicesPath = "/sys/devices/platform"
+	KFDTopologyPath = "/sys/class/kfd/kfd"
 }
 
 // PFInfo holds metadata for a Physical Function already bound to vfio-pci

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -59,5 +59,15 @@ const (
 	ComputePartitionCPX = "cpx"
 )
 
+// Memory partition modes
+const (
+	MemoryPartitionNPS1 = "nps1"
+	MemoryPartitionNPS2 = "nps2"
+	MemoryPartitionNPS3 = "nps3"
+	MemoryPartitionNPS4 = "nps4"
+	MemoryPartitionNPS6 = "nps6"
+	MemoryPartitionNPS8 = "nps8"
+)
+
 // Default partition profile for non-partitioned GPUs
 const DefaultPartitionProfile = "spx_nps1"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -54,6 +54,7 @@ const (
 const (
 	ComputePartitionSPX = "spx"
 	ComputePartitionDPX = "dpx"
+	ComputePartitionTPX = "tpx"
 	ComputePartitionQPX = "qpx"
 	ComputePartitionCPX = "cpx"
 )


### PR DESCRIPTION
## Motivation

`GetAMDGPUs` declared `card`, `renderD`, `nodeId`, and the kfd (unique) ID once before the enumeration loops and reused them for every device. A device with missing drm entries or no topology match kept the previous device's values, so it was published with another GPU's card index, render minor, node ID, or kfd ID. The XCP partition loop attaches a partition to its parent by matching kfd ID, so a stale kfd ID could bind a partition to the wrong GPU.

A second, related problem is that the identity defaulted to `card 0` / `renderD 128`. Those are valid DRM indices, not sentinels, so a device that never resolved a real identity was still published as `gpu-0-128`: it could collide with a real device in the canonical-name map and borrow renderD 128's VRAM, SIMD, and CU counts through `topologyInfo`. That borrow is the case tracked in #79.

## Change

Extract `resolveDRMIdentity`, which starts fresh on every call, so each device resolves its own identity instead of inheriting the previous one's.

Return an `ok` flag that is true only when both a `card` and a `renderD` entry resolve to a valid decimal index. `GetAMDGPUs` skips a device when `ok` is false, so discovery fails closed rather than publishing a borrowed or default identity. The platform (XCP) loop additionally requires a non-empty kfd ID, so a partition cannot match a parent by an empty identity. `parseDRMIndex` rejects a missing prefix, an empty suffix, or a non-decimal suffix instead of reading it as index 0, `nodeId`/`devID` stay tied to the current `renderD`, and conflicting `card`/`renderD` entries within one device mark the identity unresolved.

The XCP loop also looked up a partition's parent by scanning the same map it appends each partition to, so a later partition could match an earlier partition instead of the physical GPU, and Go does not define map iteration order. It now searches a snapshot of the physical GPUs taken before that loop begins, and requires exactly one match: no parent means the partition is skipped, and two GPUs reporting the same kfd id is an error naming both PCI addresses rather than a first-match guess. That lookup is a plain function over a map, so it is tested directly.

Classification of the compute-partition mode previously matched `dpx`, `qpx` and `cpx`, which dropped `tpx`. AMD's accelerator partition documentation lists SPX, DPX, TPX, QPX and CPX and notes that not all modes exist on every ASIC, with TPX valid on MI300A, so a partitioned MI300A advertised no partitions at all. All five are now classified, `spx` and an empty mode as a whole GPU and the rest as partitions, and a mode outside that set is an error rather than either extreme: publishing it would turn hardware state the driver cannot interpret into an allocatable device, and skipping it would lose a GPU with only a log line to say so.

The partition sysfs reads no longer treat a failure as an unpartitioned GPU. Both files were read with the error logged and the mode left empty, and an empty mode means "no partitioning support" further down, so a partitioned GPU whose read failed was published as one whole allocatable device. That inflates capacity rather than losing it, and the same loop already skips a device when `numa_node` cannot be read. Only a missing file now means the device does not support partitioning, which is the MI50 case in #7; any other error skips the device.

A GPU already in a partition mode is also skipped when its KFD identity has not appeared yet. The platform loop skips a partition with no kfd id, so publishing the parent on its own would advertise part of a partitioned GPU as though it were the whole topology. A device that is not partitioned is still usable whole, so only the partitioned case is dropped.

Skipping is safe per device but not over time, because enumeration runs once from `NewDeviceState` and its result becomes the fixed inventory. A startup race with amdgpu or KFD would therefore leave a healthy GPU missing from the ResourceSlice until the process restarts, which is #85. Discovery now retries a few times when something was skipped for a condition that may still resolve. A device that is still incomplete on the last attempt behaves exactly as before: skipped, never published with a borrowed identity, and not turned into a startup failure, since that trade is the maintainer's availability call.

As a backstop, `addAllocatableDevice` reports a canonical-name collision as an error instead of silently overwriting an already-discovered device.

## Tests

`TestResolveDRMIdentity` asserts the fail-closed contract: complete entries resolve (`ok=true`), while incomplete, malformed, or conflicting entries return `ok=false`. The missing-identity cases run after the complete ones, so a regression that let state carry over would fail them. `TestAddAllocatableDeviceRejectsCollision` covers the collision backstop, and `TestIsComputePartition` pins the classification, including TPX and a mode newer than this driver.

The retry is covered both ways: a GPU whose DRM entries appear during discovery ends up published, and the same case with a single attempt loses it, so the retry is doing the work rather than the delay being harmless.

Discovery itself is now covered rather than only its helpers. #50 already added `SetSysfsRoot` to redirect the VFIO paths at a temp dir; the roots discovery reads go through the same call, so a test can lay out a GPU under a fake sysfs and run `enumerateAllPossibleDevices` with no hardware. That covers a mode outside the old allowlist being discovered, a device with no DRM entries being skipped instead of borrowing the previous identity, and every partition inheriting the physical parent's PCI address. Restoring the allowlist fails only the tpx case, and disabling the identity guard publishes the incomplete device as a fabricated `gpu-0-0`.

The snapshot itself is the one part no test distinguishes. The partition test asserts the resulting parent address over repeated runs, but it still passes if the lookup scans the mutating map, because a sibling partition carries the same inherited values as the parent, so today either match produces the same answer. The snapshot removes the undefined ordering rather than a visible difference, and it matters once #88 changes partitions while the node is running. The exact-one rule layered on top of it is pinned by its own test.

## Rebase and review notes

This branch is rebased onto develop after #50. The rebase keeps the VFIO device type, discovery, and feature gate from that change; the only conflict was in `allocatable.go`, where an earlier revision of this branch had added a private `pciAddress()` helper. That helper is removed in favor of the VFIO-aware `GetPCIAddress()` now on develop, which also reports the address for a VFIO device rather than an empty string.

One behavioral note for anyone who read the earlier revision: it gated the partition branch on a fixed set of modes and skipped anything else. That gate is removed for the reason described above, so the classification is wider than in the revision that was approved.

Validation on a partitioned Instinct GPU is still outstanding, and TPX in particular needs an MI300A. The useful assertions are the physical BDF and kfd ID to XCP mapping, a unique card/render pair per partition, the expected device count per mode, and confirmation that no valid partition is dropped.

Fixes #79: skipping a device that cannot resolve a real card and renderD removes the renderD-128 topology borrow that issue describes. Also removes the cross-device identity carry-over.