### PR TITLE
fix: rebuild and verify CDI specs from the checkpoint on plugin restart

### DIFF
--- a/cmd/gpu-kubeletplugin/cdi.go
+++ b/cmd/gpu-kubeletplugin/cdi.go
@@ -110,9 +110,9 @@ func (cdi *CDIHandler) CreateClaimSpecFile(claimUID string, devices PreparedDevi
 	}
 
 	for _, device := range devices {
-		if device == nil || device.ContainerEdits == nil {
-			// Callers validate checkpoint-sourced devices first; guard here too so a
-			// nil entry can never be dereferenced into a panic at spec-build time.
+		if device == nil || device.ContainerEdits == nil || device.ContainerEdits.ContainerEdits == nil {
+			// The inner pointer is dereferenced below, so check it here rather than
+			// relying on every caller having validated the device first.
 			return fmt.Errorf("claim %s has a nil prepared device or container edits", claimUID)
 		}
 		klog.Infof("Creating CDI spec for device: %+v", device)

--- a/cmd/gpu-kubeletplugin/cdi.go
+++ b/cmd/gpu-kubeletplugin/cdi.go
@@ -110,6 +110,11 @@ func (cdi *CDIHandler) CreateClaimSpecFile(claimUID string, devices PreparedDevi
 	}
 
 	for _, device := range devices {
+		if device == nil || device.ContainerEdits == nil {
+			// Callers validate checkpoint-sourced devices first; guard here too so a
+			// nil entry can never be dereferenced into a panic at spec-build time.
+			return fmt.Errorf("claim %s has a nil prepared device or container edits", claimUID)
+		}
 		klog.Infof("Creating CDI spec for device: %+v", device)
 		claimEdits := cdiapi.ContainerEdits{}
 		claimEdits.Append(device.ContainerEdits)

--- a/cmd/gpu-kubeletplugin/cdi.go
+++ b/cmd/gpu-kubeletplugin/cdi.go
@@ -111,8 +111,7 @@ func (cdi *CDIHandler) CreateClaimSpecFile(claimUID string, devices PreparedDevi
 
 	for _, device := range devices {
 		if device == nil || device.ContainerEdits == nil || device.ContainerEdits.ContainerEdits == nil {
-			// The inner pointer is dereferenced below, so check it here rather than
-			// relying on every caller having validated the device first.
+			// Dereferenced below, and not every caller has validated the device.
 			return fmt.Errorf("claim %s has a nil prepared device or container edits", claimUID)
 		}
 		klog.Infof("Creating CDI spec for device: %+v", device)

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -210,6 +210,13 @@ func (s *DeviceState) validateCheckpointedClaim(claimUID string, preparedDevices
 	if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
 		return err
 	}
+	return s.claimDevicesAllocatable(claimUID, preparedDevices)
+}
+
+// claimDevicesAllocatable reports whether discovery currently offers every device the
+// claim was prepared with. Absence is not proof the claim is dead: discovery can be
+// incomplete, and an on-demand VFIO conversion returns the device under another name.
+func (s *DeviceState) claimDevicesAllocatable(claimUID string, preparedDevices PreparedDevices) error {
 	for _, pd := range preparedDevices {
 		if _, ok := s.allocatable[pd.DeviceName]; !ok {
 			return fmt.Errorf("checkpointed device %s for claim %s is not currently allocatable", pd.DeviceName, claimUID)
@@ -280,13 +287,11 @@ func (s *DeviceState) deviceNodesCurrent(claims PreparedClaims) bool {
 
 // reconcileCDISpecs rebuilds the per-claim CDI spec files from the checkpoint on a
 // plugin restart, which can clear the (often tmpfs) spec directory while the
-// checkpoint survives. A checkpoint from a confirmed different boot is discarded rather
-// than replayed, since a reboot also clears kubelet's prepared state. Otherwise the
-// specs are rebuilt when the device nodes still match, and startup fails when they do
-// not, because deleting them while kubelet still holds the claim would strand it. A
-// corrupt or no-longer-allocatable entry is skipped, leaving it as unusable as it
-// already was; a CDI write error fails startup, because the kubelet may not re-Prepare
-// an already-prepared claim.
+// checkpoint survives. Startup fails when a checkpointed device node no longer resolves,
+// because deleting state kubelet still holds prepared would strand the claim. A malformed
+// entry loses its stale spec; one whose device is merely absent from the inventory keeps
+// it, since absence can be incomplete discovery or an on-demand VFIO rename. A CDI write
+// error fails startup, because the kubelet may not re-Prepare an already-prepared claim.
 func (s *DeviceState) reconcileCDISpecs() error {
 	checkpoint := newCheckpoint()
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
@@ -305,20 +310,19 @@ func (s *DeviceState) reconcileCDISpecs() error {
 	}
 
 	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {
-		if err := s.validateCheckpointedClaim(claimUID, preparedDevices); err != nil {
-			// Skipped, not fatal. Failing startup here would take the whole node's GPUs
-			// down for one bad entry, and an on-demand VFIO conversion reaches this
-			// legitimately: the device comes back under its VFIO name, so the
-			// checkpointed name is no longer allocatable. Recovering that claim needs
-			// the type-aware, stable identity tracked in #83 and #86; until then the
-			// claim stays unusable and this only avoids making it worse.
-			klog.Warningf("skipping unrecoverable checkpoint entry for claim %s: %v", claimUID, err)
-			// Leaving the old spec behind on a persistent spec directory would let the
-			// runtime keep resolving the claim to device nodes that may now belong to
-			// another GPU, so remove it rather than only declining to rebuild it.
+		if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
+			// Content this malformed can never be rebuilt into a spec, so drop the
+			// authorization the old one still grants.
+			klog.Warningf("removing the spec for malformed checkpoint entry %s: %v", claimUID, err)
 			if rmErr := s.cdi.DeleteClaimSpecFile(claimUID); rmErr != nil {
-				return fmt.Errorf("unable to remove the spec for unrecoverable claim %s: %w", claimUID, rmErr)
+				return fmt.Errorf("unable to remove the spec for malformed claim %s: %w", claimUID, rmErr)
 			}
+			continue
+		}
+		if err := s.claimDevicesAllocatable(claimUID, preparedDevices); err != nil {
+			// deviceNodesCurrent already proved the nodes resolve, so an existing spec is
+			// no less valid than before this start; an on-demand VFIO device lands here.
+			klog.Warningf("leaving the spec for claim %s in place: %v", claimUID, err)
 			continue
 		}
 		if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -95,13 +95,13 @@ type DeviceState struct {
 // checksum and an older binary that does not know about it stays rollback-safe.
 const bootEpochFile = "boot-epoch"
 
-// readBootID returns the current boot identifier from procfs. It changes on every
-// node reboot. An unreadable value is returned empty, which the reconcile guard
-// treats as untrusted and fails closed onto re-preparation.
+// readBootID returns the current boot identifier from procfs. It changes on every node
+// reboot. An unreadable value is returned empty, which cannot confirm a reboot, so the
+// checkpoint is kept and verified against the host rather than discarded.
 func readBootID() string {
 	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
 	if err != nil {
-		klog.Warningf("unable to read boot id (%v); checkpoint recovery will fail closed", err)
+		klog.Warningf("unable to read boot id (%v); a reboot cannot be confirmed, so the checkpoint will be verified instead of discarded", err)
 		return ""
 	}
 	return strings.TrimSpace(string(data))
@@ -122,6 +122,12 @@ func (s *DeviceState) readStoredEpoch() string {
 }
 
 func (s *DeviceState) writeEpoch(id string) error {
+	if id == "" {
+		// Recording an empty epoch would destroy the only value a later reboot can be
+		// detected against, so keep whatever is already stored.
+		klog.Warning("boot id unavailable; leaving the recorded boot epoch unchanged")
+		return nil
+	}
 	if err := os.WriteFile(s.epochPath(), []byte(id), 0600); err != nil {
 		return fmt.Errorf("unable to record boot epoch: %w", err)
 	}
@@ -331,8 +337,9 @@ func (s *DeviceState) deviceNodesCurrent(claims PreparedClaims) bool {
 // than replayed, since a reboot also clears kubelet's prepared state. Otherwise the
 // specs are rebuilt when the device nodes still match, and startup fails when they do
 // not, because deleting them while kubelet still holds the claim would strand it. A
-// corrupt or no-longer-allocatable entry is quarantined; a CDI write error fails
-// startup, because the kubelet may not re-Prepare an already-prepared claim.
+// corrupt or no-longer-allocatable entry is skipped, leaving it as unusable as it
+// already was; a CDI write error fails startup, because the kubelet may not re-Prepare
+// an already-prepared claim.
 func (s *DeviceState) reconcileCDISpecs() error {
 	checkpoint := newCheckpoint()
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
@@ -371,8 +378,12 @@ func (s *DeviceState) reconcileCDISpecs() error {
 
 	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {
 		if err := s.validateCheckpointedClaim(claimUID, preparedDevices); err != nil {
-			// Corrupt or no-longer-allocatable entry: quarantine it and keep going,
-			// rather than crash the plugin on a single bad claim.
+			// Skipped, not fatal. Failing startup here would take the whole node's GPUs
+			// down for one bad entry, and an on-demand VFIO conversion reaches this
+			// legitimately: the device comes back under its VFIO name, so the
+			// checkpointed name is no longer allocatable. Recovering that claim needs
+			// the type-aware, stable identity tracked in #83 and #86; until then the
+			// claim stays unusable and this only avoids making it worse.
 			klog.Warningf("skipping unrecoverable checkpoint entry for claim %s: %v", claimUID, err)
 			continue
 		}

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -327,8 +327,10 @@ func (s *DeviceState) deviceNodesCurrent(claims PreparedClaims) bool {
 
 // reconcileCDISpecs rebuilds the per-claim CDI spec files from the checkpoint on a
 // plugin restart, which can clear the (often tmpfs) spec directory while the
-// checkpoint survives. Replay is gated on a boot epoch: a checkpoint from a different
-// boot is discarded rather than replayed, so stale device nodes are never rebuilt. A
+// checkpoint survives. A checkpoint from a confirmed different boot is discarded rather
+// than replayed, since a reboot also clears kubelet's prepared state. Otherwise the
+// specs are rebuilt when the device nodes still match, and startup fails when they do
+// not, because deleting them while kubelet still holds the claim would strand it. A
 // corrupt or no-longer-allocatable entry is quarantined; a CDI write error fails
 // startup, because the kubelet may not re-Prepare an already-prepared claim.
 func (s *DeviceState) reconcileCDISpecs() error {
@@ -340,28 +342,31 @@ func (s *DeviceState) reconcileCDISpecs() error {
 		return fmt.Errorf("checkpoint has no v1 payload")
 	}
 
-	// The checkpointed edits carry the /dev/kfd major and DRM card/render numbers seen
-	// when each claim was prepared, and a node reboot can renumber them. Replay is only
-	// trusted within the boot that wrote the checkpoint: if the recorded epoch is missing
-	// or does not match the current boot, discard the claims (and their now-stale specs)
-	// instead of rebuilding a spec that may point at a different GPU. The boot id does not
-	// change on a same-boot driver reload, so that narrower renumbering is not covered
-	// here; safe cross-boot and cross-reload recovery both need the stable device identity
-	// tracked in #83. The first restart after this epoch field is introduced has no
-	// recorded epoch and so also discards once, then records the current boot.
+	// Discarding the checkpoint deletes the CDI spec files that kubelet's cached CDI IDs
+	// resolve against. That is only safe when kubelet has also dropped its prepared-claim
+	// state, which happens across a real reboot. A reboot changes the boot id, so only a
+	// recorded epoch that is present and differs from the current boot proves one. A
+	// missing or unreadable epoch does not: the first restart after this field was added
+	// has none, and a plugin-only upgrade keeps the same kubelet running. In those cases
+	// kubelet still considers the claims prepared and will not call Prepare again, so
+	// discarding here would strand them with no spec to resolve. Cross-boot and
+	// cross-reload device identity still need the stable name tracked in #83.
 	stored := s.readStoredEpoch()
-	if s.bootID == "" || stored == "" || stored != s.bootID {
-		klog.Warningf("checkpoint boot epoch %q does not match current %q; discarding %d checkpointed claim(s) without replay", stored, s.bootID, len(checkpoint.V1.PreparedClaims))
+	if stored != "" && s.bootID != "" && stored != s.bootID {
+		klog.Warningf("checkpoint boot epoch %q differs from current boot %q; discarding %d checkpointed claim(s) without replay", stored, s.bootID, len(checkpoint.V1.PreparedClaims))
 		return s.discardCheckpoint(checkpoint.V1.PreparedClaims)
 	}
 
-	// Same boot, but a driver reload can still renumber a device node, or remove it,
-	// without changing the boot id. If any checkpointed node no longer matches the host,
-	// the edits are stale, so discard instead of rebuilding a spec that points at the
-	// wrong numbers.
+	// Same boot, or a boot that cannot be confirmed. kubelet has not necessarily
+	// restarted, so its prepared claims must be preserved. A same-boot driver reload can
+	// still renumber a device node (for example /dev/kfd's major) without changing the
+	// boot id: rebuild the specs when every checkpointed node still resolves to its
+	// recorded numbers, and fail startup when one does not, rather than discarding and
+	// registering healthy while kubelet keeps the claim. Rebuilding a spec that points at
+	// the wrong numbers, or silently dropping a claim kubelet still holds, are both worse
+	// than refusing to start and letting an operator drain or restart kubelet.
 	if !s.deviceNodesCurrent(checkpoint.V1.PreparedClaims) {
-		klog.Warningf("checkpointed device nodes no longer match the host; discarding %d claim(s) without replay", len(checkpoint.V1.PreparedClaims))
-		return s.discardCheckpoint(checkpoint.V1.PreparedClaims)
+		return fmt.Errorf("checkpointed device nodes no longer match the host and the boot epoch (stored %q, current %q) does not confirm a reboot; refusing to discard %d claim(s) kubelet may still consider prepared", stored, s.bootID, len(checkpoint.V1.PreparedClaims))
 	}
 
 	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -85,6 +86,64 @@ type DeviceState struct {
 	checkpointManager    checkpointmanager.CheckpointManager
 	vfioManager          *VfioPciManager
 	claimVfioConversions map[string]*AmdGpuInfo
+	pluginPath           string
+	bootID               string
+}
+
+// bootEpochFile records the boot the checkpoint's claims were prepared under. It
+// lives next to the checkpoint but outside it, so it does not change the checkpoint
+// checksum and an older binary that does not know about it stays rollback-safe.
+const bootEpochFile = "boot-epoch"
+
+// readBootID returns the current boot identifier from procfs. It changes on every
+// node reboot. An unreadable value is returned empty, which the reconcile guard
+// treats as untrusted and fails closed onto re-preparation.
+func readBootID() string {
+	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		klog.Warningf("unable to read boot id (%v); checkpoint recovery will fail closed", err)
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func (s *DeviceState) epochPath() string {
+	return filepath.Join(s.pluginPath, bootEpochFile)
+}
+
+// readStoredEpoch returns the boot id recorded when the checkpoint was last written,
+// or empty if it is absent or unreadable (both treated as untrusted).
+func (s *DeviceState) readStoredEpoch() string {
+	data, err := os.ReadFile(s.epochPath())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func (s *DeviceState) writeEpoch(id string) error {
+	if err := os.WriteFile(s.epochPath(), []byte(id), 0600); err != nil {
+		return fmt.Errorf("unable to record boot epoch: %w", err)
+	}
+	return nil
+}
+
+// discardCheckpoint removes any CDI spec files for the given claims and then replaces
+// the on-disk checkpoint with an empty one. Used when the recorded boot epoch no longer
+// matches: the checkpointed device nodes may now point at different hardware, so the
+// specs must not survive on a persistent spec directory where the container runtime
+// could still resolve a claim against them. RemoveSpec tolerates an already-absent
+// file, which is the common tmpfs case.
+func (s *DeviceState) discardCheckpoint(claims PreparedClaims) error {
+	for claimUID := range claims {
+		if err := s.cdi.DeleteClaimSpecFile(claimUID); err != nil {
+			return fmt.Errorf("unable to remove stale CDI spec for claim %s: %w", claimUID, err)
+		}
+	}
+	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, newCheckpoint()); err != nil {
+		return fmt.Errorf("unable to discard stale checkpoint: %w", err)
+	}
+	return nil
 }
 
 func NewDeviceState(config *Config) (*DeviceState, error) {
@@ -128,6 +187,8 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 		allocatable:       allocatable,
 		vfioManager:       vfioMgr,
 		checkpointManager: checkpointManager,
+		pluginPath:        config.DriverPluginPath(),
+		bootID:            readBootID(),
 	}
 
 	checkpoints, err := state.checkpointManager.ListCheckpoints()
@@ -140,6 +201,11 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 			if err := state.reconcileCDISpecs(); err != nil {
 				return nil, fmt.Errorf("unable to reconcile CDI spec files from checkpoint: %v", err)
 			}
+			// Record the current boot after reconcile, which reads the previous value,
+			// so a later same-boot restart replays and a reboot fails closed.
+			if err := state.writeEpoch(state.bootID); err != nil {
+				return nil, err
+			}
 			return state, nil
 		}
 	}
@@ -147,6 +213,9 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 	checkpoint := newCheckpoint()
 	if err := state.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
 		return nil, fmt.Errorf("unable to sync to checkpoint: %v", err)
+	}
+	if err := state.writeEpoch(state.bootID); err != nil {
+		return nil, err
 	}
 
 	return state, nil
@@ -169,6 +238,47 @@ func validatePreparedDevices(claimUID string, preparedDevices PreparedDevices) e
 		if pd.ContainerEdits == nil || pd.ContainerEdits.ContainerEdits == nil {
 			return fmt.Errorf("checkpoint entry for claim %s device %s has no container edits", claimUID, pd.DeviceName)
 		}
+		// A non-nil wrapper can still carry nil entries in its pointer slices; CDI
+		// dereferences these while determining the spec version, so a nil entry would
+		// panic before CreateClaimSpecFile could return a normal error.
+		edits := pd.ContainerEdits.ContainerEdits
+		for i, n := range edits.DeviceNodes {
+			if n == nil {
+				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil deviceNodes[%d]", claimUID, pd.DeviceName, i)
+			}
+		}
+		for i, h := range edits.Hooks {
+			if h == nil {
+				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil hooks[%d]", claimUID, pd.DeviceName, i)
+			}
+		}
+		for i, m := range edits.Mounts {
+			if m == nil {
+				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil mounts[%d]", claimUID, pd.DeviceName, i)
+			}
+		}
+		for i, nd := range edits.NetDevices {
+			if nd == nil {
+				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil netDevices[%d]", claimUID, pd.DeviceName, i)
+			}
+		}
+	}
+	return nil
+}
+
+// validateCheckpointedClaim rejects a checkpoint entry that cannot be safely turned
+// into a CDI spec: one that is structurally corrupt, or that names a device not in
+// the current allocatable inventory (removed, repartitioned, or skipped by discovery
+// this boot). The name match is necessary but not sufficient; proving it is the same
+// physical GPU needs the stable identity tracked in #83.
+func (s *DeviceState) validateCheckpointedClaim(claimUID string, preparedDevices PreparedDevices) error {
+	if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
+		return err
+	}
+	for _, pd := range preparedDevices {
+		if _, ok := s.allocatable[pd.DeviceName]; !ok {
+			return fmt.Errorf("checkpointed device %s for claim %s is not currently allocatable", pd.DeviceName, claimUID)
+		}
 	}
 	return nil
 }
@@ -177,7 +287,7 @@ func validatePreparedDevices(claimUID string, preparedDevices PreparedDevices) e
 // claim reported as prepared from the checkpoint is actually usable. It is safe to
 // call repeatedly: CreateClaimSpecFile overwrites the deterministic spec path.
 func (s *DeviceState) ensureClaimSpec(claimUID string, preparedDevices PreparedDevices) error {
-	if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
+	if err := s.validateCheckpointedClaim(claimUID, preparedDevices); err != nil {
 		return err
 	}
 	if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
@@ -188,9 +298,10 @@ func (s *DeviceState) ensureClaimSpec(claimUID string, preparedDevices PreparedD
 
 // reconcileCDISpecs rebuilds the per-claim CDI spec files from the checkpoint on a
 // plugin restart, which can clear the (often tmpfs) spec directory while the
-// checkpoint survives. A claim that fails to rebuild is logged, not fatal; the next
-// Prepare retries it. Recovery replays the checkpointed edits as-is, so it is
-// correct within a boot but not across a node reboot that renumbers device nodes.
+// checkpoint survives. Replay is gated on a boot epoch: a checkpoint from a different
+// boot is discarded rather than replayed, so stale device nodes are never rebuilt. A
+// corrupt or no-longer-allocatable entry is quarantined; a CDI write error fails
+// startup, because the kubelet may not re-Prepare an already-prepared claim.
 func (s *DeviceState) reconcileCDISpecs() error {
 	checkpoint := newCheckpoint()
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
@@ -200,9 +311,33 @@ func (s *DeviceState) reconcileCDISpecs() error {
 		return fmt.Errorf("checkpoint has no v1 payload")
 	}
 
+	// The checkpointed edits carry the /dev/kfd major and DRM card/render numbers seen
+	// when each claim was prepared, and a node reboot can renumber them. Replay is only
+	// trusted within the boot that wrote the checkpoint: if the recorded epoch is missing
+	// or does not match the current boot, discard the claims (and their now-stale specs)
+	// instead of rebuilding a spec that may point at a different GPU. The boot id does not
+	// change on a same-boot driver reload, so that narrower renumbering is not covered
+	// here; safe cross-boot and cross-reload recovery both need the stable device identity
+	// tracked in #83. The first restart after this epoch field is introduced has no
+	// recorded epoch and so also discards once, then records the current boot.
+	stored := s.readStoredEpoch()
+	if s.bootID == "" || stored == "" || stored != s.bootID {
+		klog.Warningf("checkpoint boot epoch %q does not match current %q; discarding %d checkpointed claim(s) without replay", stored, s.bootID, len(checkpoint.V1.PreparedClaims))
+		return s.discardCheckpoint(checkpoint.V1.PreparedClaims)
+	}
+
 	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {
-		if err := s.ensureClaimSpec(claimUID, preparedDevices); err != nil {
-			klog.Warningf("unable to rebuild CDI spec for claim %s on startup; the next Prepare will retry: %v", claimUID, err)
+		if err := s.validateCheckpointedClaim(claimUID, preparedDevices); err != nil {
+			// Corrupt or no-longer-allocatable entry: quarantine it and keep going,
+			// rather than crash the plugin on a single bad claim.
+			klog.Warningf("skipping unrecoverable checkpoint entry for claim %s: %v", claimUID, err)
+			continue
+		}
+		if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
+			// A CDI write or filesystem error is not self-healing: the kubelet may keep
+			// the claim marked prepared and never call Prepare again, so fail startup
+			// loudly instead of registering with a missing spec.
+			return fmt.Errorf("rebuild CDI spec for claim %s on startup: %w", claimUID, err)
 		}
 	}
 	return nil
@@ -220,6 +355,11 @@ func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Devi
 	}
 	if checkpoint.V1 == nil {
 		return nil, fmt.Errorf("checkpoint has no v1 payload")
+	}
+	if checkpoint.V1.PreparedClaims == nil {
+		// An explicit "preparedClaims": null decodes to a nil map; initialize it so the
+		// assignment below does not panic.
+		checkpoint.V1.PreparedClaims = make(PreparedClaims)
 	}
 	preparedClaims := checkpoint.V1.PreparedClaims
 

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -33,13 +33,11 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -53,7 +51,6 @@ import (
 	klog "k8s.io/klog/v2"
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
-	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
@@ -88,116 +85,6 @@ type DeviceState struct {
 	checkpointManager    checkpointmanager.CheckpointManager
 	vfioManager          *VfioPciManager
 	claimVfioConversions map[string]*AmdGpuInfo
-	pluginPath           string
-	bootID               string
-}
-
-// bootEpochFile records the boot the checkpoint's claims were prepared under. It
-// lives next to the checkpoint but outside it, so it does not change the checkpoint
-// checksum and an older binary that does not know about it stays rollback-safe.
-const bootEpochFile = "boot-epoch"
-
-// readBootID returns the current boot identifier from procfs. It changes on every node
-// reboot. An unreadable value is returned empty, which cannot confirm a reboot, so the
-// checkpoint is kept and verified against the host rather than discarded.
-func readBootID() string {
-	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
-	if err != nil {
-		klog.Warningf("unable to read boot id (%v); a reboot cannot be confirmed, so the checkpoint will be verified instead of discarded", err)
-		return ""
-	}
-	return strings.TrimSpace(string(data))
-}
-
-func (s *DeviceState) epochPath() string {
-	return filepath.Join(s.pluginPath, bootEpochFile)
-}
-
-// epochRecord ties a boot id to the checkpoint it was written for. The checksum is what
-// separates "we rebooted and nothing has written the checkpoint since" from "some other
-// binary wrote it after this was recorded", and only the first is safe to discard.
-type epochRecord struct {
-	BootID     string            `json:"bootID"`
-	Checkpoint checksum.Checksum `json:"checkpoint"`
-}
-
-// readStoredEpoch returns the recorded epoch and whether it can be trusted. Absent,
-// unreadable, and unparsable are all untrusted, which keeps the checkpoint rather than
-// discarding it. The pre-record format was a bare boot id, so it also reads as untrusted.
-func (s *DeviceState) readStoredEpoch() (epochRecord, bool) {
-	data, err := os.ReadFile(s.epochPath())
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			klog.Warningf("unable to read the boot epoch (%v); treating it as unknown", err)
-		}
-		return epochRecord{}, false
-	}
-	var rec epochRecord
-	if err := json.Unmarshal(data, &rec); err != nil || rec.BootID == "" {
-		klog.Warningf("boot epoch at %s is not a usable record; treating it as unknown", s.epochPath())
-		return epochRecord{}, false
-	}
-	return rec, true
-}
-
-// writeEpoch records the boot and checkpoint the plugin is running against. It replaces
-// the file atomically, since a half-written record would read as a different boot and
-// authorize discarding claims.
-func (s *DeviceState) writeEpoch(ck checksum.Checksum) error {
-	if s.bootID == "" {
-		// Recording an empty boot id would lose the only value a later reboot can be
-		// detected against, so keep whatever is already stored.
-		klog.Warning("boot id unavailable; leaving the recorded boot epoch unchanged")
-		return nil
-	}
-	data, err := json.Marshal(epochRecord{BootID: s.bootID, Checkpoint: ck})
-	if err != nil {
-		return fmt.Errorf("unable to encode boot epoch: %w", err)
-	}
-	tmp := s.epochPath() + ".tmp"
-	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("unable to record boot epoch: %w", err)
-	}
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		return fmt.Errorf("unable to record boot epoch: %w", err)
-	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		return fmt.Errorf("unable to record boot epoch: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("unable to record boot epoch: %w", err)
-	}
-	return os.Rename(tmp, s.epochPath())
-}
-
-// saveCheckpoint writes the checkpoint and the epoch describing it together, so the two
-// never drift apart. CreateCheckpoint fills in the checksum recorded here.
-func (s *DeviceState) saveCheckpoint(cp *Checkpoint) error {
-	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, cp); err != nil {
-		return err
-	}
-	return s.writeEpoch(cp.Checksum)
-}
-
-// discardCheckpoint removes any CDI spec files for the given claims and then replaces
-// the on-disk checkpoint with an empty one. Used when the recorded boot epoch no longer
-// matches: the checkpointed device nodes may now point at different hardware, so the
-// specs must not survive on a persistent spec directory where the container runtime
-// could still resolve a claim against them. RemoveSpec tolerates an already-absent
-// file, which is the common tmpfs case.
-func (s *DeviceState) discardCheckpoint(claims PreparedClaims) error {
-	for claimUID := range claims {
-		if err := s.cdi.DeleteClaimSpecFile(claimUID); err != nil {
-			return fmt.Errorf("unable to remove stale CDI spec for claim %s: %w", claimUID, err)
-		}
-	}
-	if err := s.saveCheckpoint(newCheckpoint()); err != nil {
-		return fmt.Errorf("unable to discard stale checkpoint: %w", err)
-	}
-	return nil
 }
 
 func NewDeviceState(config *Config) (*DeviceState, error) {
@@ -241,8 +128,6 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 		allocatable:       allocatable,
 		vfioManager:       vfioMgr,
 		checkpointManager: checkpointManager,
-		pluginPath:        config.DriverPluginPath(),
-		bootID:            readBootID(),
 	}
 
 	checkpoints, err := state.checkpointManager.ListCheckpoints()
@@ -255,20 +140,11 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 			if err := state.reconcileCDISpecs(); err != nil {
 				return nil, fmt.Errorf("unable to reconcile CDI spec files from checkpoint: %v", err)
 			}
-			// Rebind the epoch to whatever the checkpoint is now, after reconcile has
-			// read the previous one and possibly discarded.
-			current := newCheckpoint()
-			if err := state.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, current); err != nil {
-				return nil, fmt.Errorf("unable to sync from checkpoint: %v", err)
-			}
-			if err := state.writeEpoch(current.Checksum); err != nil {
-				return nil, err
-			}
 			return state, nil
 		}
 	}
 
-	if err := state.saveCheckpoint(newCheckpoint()); err != nil {
+	if err := state.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, newCheckpoint()); err != nil {
 		return nil, fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 
@@ -359,14 +235,13 @@ func (s *DeviceState) ensureClaimSpec(claimUID string, preparedDevices PreparedD
 	return nil
 }
 
-// deviceNodesCurrent reports whether every checkpointed device node still resolves to
-// the major/minor it was prepared with. The boot epoch catches a reboot; this catches a
-// same-boot change that moves a node's numbers without changing the boot id, for example
-// /dev/kfd's dynamically allocated major after a KFD reload, or a node whose path no
-// longer exists. It does NOT catch a node that keeps the same numbers but now backs a
-// different physical GPU (the DRM card/render minors are stable per path), which needs
-// the stable identity tracked in #83. Malformed entries (nil device, nil wrapper, nil
-// node) are left to validateCheckpointedClaim; this skips them.
+// deviceNodesCurrent reports whether every checkpointed device node still resolves on the
+// host. It is the only check that the checkpoint still describes this machine, so a node
+// that cannot be stat'd, changed type, or moved to different numbers fails it. CDI lets a
+// node carry only a path, with the host path defaulting to Path and the numbers resolved
+// by the runtime, and the VFIO path emits exactly that, so those are verified by path
+// rather than skipped. It does NOT catch a node that keeps its numbers but now backs a
+// different GPU, which needs the stable identity tracked in #83.
 func (s *DeviceState) deviceNodesCurrent(claims PreparedClaims) bool {
 	for _, preparedDevices := range claims {
 		for _, pd := range preparedDevices {
@@ -374,12 +249,27 @@ func (s *DeviceState) deviceNodesCurrent(claims PreparedClaims) bool {
 				continue
 			}
 			for _, n := range pd.ContainerEdits.ContainerEdits.DeviceNodes {
-				if n == nil || n.HostPath == "" || (n.Major == 0 && n.Minor == 0) {
+				if n == nil {
 					continue
 				}
-				major, minor, _, _, err := getDeviceAttrs(n.HostPath)
-				if err != nil || major != n.Major || minor != n.Minor {
-					klog.Warningf("checkpointed device node %s resolves to %d:%d now, recorded %d:%d (err=%v); the checkpoint is stale", n.HostPath, major, minor, n.Major, n.Minor, err)
+				hostPath := n.HostPath
+				if hostPath == "" {
+					hostPath = n.Path
+				}
+				if hostPath == "" {
+					continue
+				}
+				major, minor, devType, _, err := getDeviceAttrs(hostPath)
+				if err != nil {
+					klog.Warningf("checkpointed device node %s no longer resolves (%v); the checkpoint is stale", hostPath, err)
+					return false
+				}
+				if n.Type != "" && n.Type != devType {
+					klog.Warningf("checkpointed device node %s is type %q now, recorded %q; the checkpoint is stale", hostPath, devType, n.Type)
+					return false
+				}
+				if (n.Major != 0 || n.Minor != 0) && (major != n.Major || minor != n.Minor) {
+					klog.Warningf("checkpointed device node %s resolves to %d:%d now, recorded %d:%d; the checkpoint is stale", hostPath, major, minor, n.Major, n.Minor)
 					return false
 				}
 			}
@@ -406,39 +296,12 @@ func (s *DeviceState) reconcileCDISpecs() error {
 		return fmt.Errorf("checkpoint has no v1 payload")
 	}
 
-	// Discarding the checkpoint deletes the CDI spec files that kubelet's cached CDI IDs
-	// resolve against. That is only safe when kubelet has also dropped its prepared-claim
-	// state, which happens across a real reboot. A reboot changes the boot id, so only a
-	// recorded epoch that is present and differs from the current boot proves one. A
-	// missing or unreadable epoch does not: the first restart after this field was added
-	// has none, and a plugin-only upgrade keeps the same kubelet running. In those cases
-	// kubelet still considers the claims prepared and will not call Prepare again, so
-	// discarding here would strand them with no spec to resolve. Cross-boot and
-	// cross-reload device identity still need the stable name tracked in #83.
-	stored, trusted := s.readStoredEpoch()
-	switch {
-	case !trusted || s.bootID == "":
-		// Nothing to compare against, so the checkpoint is kept and verified below.
-	case stored.Checkpoint != checkpoint.Checksum:
-		// The checkpoint was written after this epoch was recorded, so it describes
-		// claims some other binary prepared. A reboot cannot be attributed to them, and
-		// discarding would drop claims kubelet may hold from that later Prepare.
-		klog.Warningf("boot epoch describes checkpoint %d but the checkpoint is now %d; keeping it and verifying instead of discarding", stored.Checkpoint, checkpoint.Checksum)
-	case stored.BootID != s.bootID:
-		klog.Warningf("checkpoint boot epoch %q differs from current boot %q; discarding %d checkpointed claim(s) without replay", stored.BootID, s.bootID, len(checkpoint.V1.PreparedClaims))
-		return s.discardCheckpoint(checkpoint.V1.PreparedClaims)
-	}
-
-	// Same boot, or a boot that cannot be confirmed. kubelet has not necessarily
-	// restarted, so its prepared claims must be preserved. A same-boot driver reload can
-	// still renumber a device node (for example /dev/kfd's major) without changing the
-	// boot id: rebuild the specs when every checkpointed node still resolves to its
-	// recorded numbers, and fail startup when one does not, rather than discarding and
-	// registering healthy while kubelet keeps the claim. Rebuilding a spec that points at
-	// the wrong numbers, or silently dropping a claim kubelet still holds, are both worse
-	// than refusing to start and letting an operator drain or restart kubelet.
+	// Nothing here removes checkpointed state. kubelet does not call Prepare again for a
+	// claim it still considers prepared, so dropping one would strand it, and telling
+	// this boot apart from the one the claims were prepared in needs the stable identity
+	// in #83. Rebuild what still matches the host and refuse to start otherwise.
 	if !s.deviceNodesCurrent(checkpoint.V1.PreparedClaims) {
-		return fmt.Errorf("checkpointed device nodes no longer match the host and the boot epoch (stored %q, current %q) does not confirm a reboot; refusing to discard %d claim(s) kubelet may still consider prepared", stored.BootID, s.bootID, len(checkpoint.V1.PreparedClaims))
+		return fmt.Errorf("checkpointed device nodes no longer match the host; refusing to serve %d claim(s) kubelet may still consider prepared", len(checkpoint.V1.PreparedClaims))
 	}
 
 	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {
@@ -507,7 +370,7 @@ func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Devi
 	}
 
 	preparedClaims[claimUID] = preparedDevices
-	if err := s.saveCheckpoint(checkpoint); err != nil {
+	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
 		return nil, fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 
@@ -547,7 +410,7 @@ func (s *DeviceState) Unprepare(claimUID string) error {
 	}
 
 	delete(preparedClaims, claimUID)
-	if err := s.saveCheckpoint(checkpoint); err != nil {
+	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
 		return fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -137,6 +137,9 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 
 	for _, c := range checkpoints {
 		if c == DriverPluginCheckpointFile {
+			if err := state.reconcileCDISpecs(); err != nil {
+				return nil, fmt.Errorf("unable to reconcile CDI spec files from checkpoint: %v", err)
+			}
 			return state, nil
 		}
 	}
@@ -149,6 +152,62 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 	return state, nil
 }
 
+// validatePreparedDevices rejects a checkpoint entry that cannot be turned into a
+// CDI spec, so a corrupt or partial checkpoint fails the claim loudly rather than
+// panicking at startup or reporting a claim as prepared when it is not.
+func validatePreparedDevices(claimUID string, preparedDevices PreparedDevices) error {
+	if len(preparedDevices) == 0 {
+		return fmt.Errorf("checkpoint entry for claim %s has no prepared devices", claimUID)
+	}
+	for _, pd := range preparedDevices {
+		if pd == nil {
+			return fmt.Errorf("checkpoint entry for claim %s has a nil prepared device", claimUID)
+		}
+		if pd.DeviceName == "" {
+			return fmt.Errorf("checkpoint entry for claim %s has a device with no name", claimUID)
+		}
+		if pd.ContainerEdits == nil || pd.ContainerEdits.ContainerEdits == nil {
+			return fmt.Errorf("checkpoint entry for claim %s device %s has no container edits", claimUID, pd.DeviceName)
+		}
+	}
+	return nil
+}
+
+// ensureClaimSpec makes sure the CDI spec for a checkpointed claim exists, so a
+// claim reported as prepared from the checkpoint is actually usable. It is safe to
+// call repeatedly: CreateClaimSpecFile overwrites the deterministic spec path.
+func (s *DeviceState) ensureClaimSpec(claimUID string, preparedDevices PreparedDevices) error {
+	if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
+		return err
+	}
+	if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
+		return fmt.Errorf("ensure CDI spec for claim %s: %w", claimUID, err)
+	}
+	return nil
+}
+
+// reconcileCDISpecs rebuilds the per-claim CDI spec files from the checkpoint on a
+// plugin restart, which can clear the (often tmpfs) spec directory while the
+// checkpoint survives. A claim that fails to rebuild is logged, not fatal; the next
+// Prepare retries it. Recovery replays the checkpointed edits as-is, so it is
+// correct within a boot but not across a node reboot that renumbers device nodes.
+func (s *DeviceState) reconcileCDISpecs() error {
+	checkpoint := newCheckpoint()
+	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
+		return fmt.Errorf("unable to sync from checkpoint: %v", err)
+	}
+	if checkpoint.V1 == nil {
+		return fmt.Errorf("checkpoint has no v1 payload")
+	}
+
+	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {
+		if err := s.ensureClaimSpec(claimUID, preparedDevices); err != nil {
+			klog.Warningf("unable to rebuild CDI spec for claim %s on startup; the next Prepare will retry: %v", claimUID, err)
+		}
+	}
+	return nil
+}
+
 func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Device, error) {
 	s.Lock()
 	defer s.Unlock()
@@ -159,10 +218,18 @@ func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Devi
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
 		return nil, fmt.Errorf("unable to sync from checkpoint: %v", err)
 	}
+	if checkpoint.V1 == nil {
+		return nil, fmt.Errorf("checkpoint has no v1 payload")
+	}
 	preparedClaims := checkpoint.V1.PreparedClaims
 
-	if preparedClaims[claimUID] != nil {
-		return preparedClaims[claimUID].GetDevices(), nil
+	if preparedDevices := preparedClaims[claimUID]; preparedDevices != nil {
+		// The spec directory can be cleared (tmpfs) while the checkpoint survives, so
+		// make sure the spec exists before reporting the claim as already prepared.
+		if err := s.ensureClaimSpec(claimUID, preparedDevices); err != nil {
+			return nil, err
+		}
+		return preparedDevices.GetDevices(), nil
 	}
 
 	preparedDevices, err := s.prepareDevices(claim)
@@ -189,6 +256,9 @@ func (s *DeviceState) Unprepare(claimUID string) error {
 	checkpoint := newCheckpoint()
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
 		return fmt.Errorf("unable to sync from checkpoint: %v", err)
+	}
+	if checkpoint.V1 == nil {
+		return fmt.Errorf("checkpoint has no v1 payload")
 	}
 	preparedClaims := checkpoint.V1.PreparedClaims
 

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -33,6 +33,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -52,6 +53,7 @@ import (
 	klog "k8s.io/klog/v2"
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
@@ -111,27 +113,73 @@ func (s *DeviceState) epochPath() string {
 	return filepath.Join(s.pluginPath, bootEpochFile)
 }
 
-// readStoredEpoch returns the boot id recorded when the checkpoint was last written,
-// or empty if it is absent or unreadable (both treated as untrusted).
-func (s *DeviceState) readStoredEpoch() string {
-	data, err := os.ReadFile(s.epochPath())
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
+// epochRecord ties a boot id to the checkpoint it was written for. The checksum is what
+// separates "we rebooted and nothing has written the checkpoint since" from "some other
+// binary wrote it after this was recorded", and only the first is safe to discard.
+type epochRecord struct {
+	BootID     string            `json:"bootID"`
+	Checkpoint checksum.Checksum `json:"checkpoint"`
 }
 
-func (s *DeviceState) writeEpoch(id string) error {
-	if id == "" {
-		// Recording an empty epoch would destroy the only value a later reboot can be
+// readStoredEpoch returns the recorded epoch and whether it can be trusted. Absent,
+// unreadable, and unparsable are all untrusted, which keeps the checkpoint rather than
+// discarding it. The pre-record format was a bare boot id, so it also reads as untrusted.
+func (s *DeviceState) readStoredEpoch() (epochRecord, bool) {
+	data, err := os.ReadFile(s.epochPath())
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			klog.Warningf("unable to read the boot epoch (%v); treating it as unknown", err)
+		}
+		return epochRecord{}, false
+	}
+	var rec epochRecord
+	if err := json.Unmarshal(data, &rec); err != nil || rec.BootID == "" {
+		klog.Warningf("boot epoch at %s is not a usable record; treating it as unknown", s.epochPath())
+		return epochRecord{}, false
+	}
+	return rec, true
+}
+
+// writeEpoch records the boot and checkpoint the plugin is running against. It replaces
+// the file atomically, since a half-written record would read as a different boot and
+// authorize discarding claims.
+func (s *DeviceState) writeEpoch(ck checksum.Checksum) error {
+	if s.bootID == "" {
+		// Recording an empty boot id would lose the only value a later reboot can be
 		// detected against, so keep whatever is already stored.
 		klog.Warning("boot id unavailable; leaving the recorded boot epoch unchanged")
 		return nil
 	}
-	if err := os.WriteFile(s.epochPath(), []byte(id), 0600); err != nil {
+	data, err := json.Marshal(epochRecord{BootID: s.bootID, Checkpoint: ck})
+	if err != nil {
+		return fmt.Errorf("unable to encode boot epoch: %w", err)
+	}
+	tmp := s.epochPath() + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
 		return fmt.Errorf("unable to record boot epoch: %w", err)
 	}
-	return nil
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return fmt.Errorf("unable to record boot epoch: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return fmt.Errorf("unable to record boot epoch: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("unable to record boot epoch: %w", err)
+	}
+	return os.Rename(tmp, s.epochPath())
+}
+
+// saveCheckpoint writes the checkpoint and the epoch describing it together, so the two
+// never drift apart. CreateCheckpoint fills in the checksum recorded here.
+func (s *DeviceState) saveCheckpoint(cp *Checkpoint) error {
+	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, cp); err != nil {
+		return err
+	}
+	return s.writeEpoch(cp.Checksum)
 }
 
 // discardCheckpoint removes any CDI spec files for the given claims and then replaces
@@ -146,7 +194,7 @@ func (s *DeviceState) discardCheckpoint(claims PreparedClaims) error {
 			return fmt.Errorf("unable to remove stale CDI spec for claim %s: %w", claimUID, err)
 		}
 	}
-	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, newCheckpoint()); err != nil {
+	if err := s.saveCheckpoint(newCheckpoint()); err != nil {
 		return fmt.Errorf("unable to discard stale checkpoint: %w", err)
 	}
 	return nil
@@ -207,21 +255,21 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 			if err := state.reconcileCDISpecs(); err != nil {
 				return nil, fmt.Errorf("unable to reconcile CDI spec files from checkpoint: %v", err)
 			}
-			// Record the current boot after reconcile, which reads the previous value,
-			// so a later same-boot restart replays and a reboot fails closed.
-			if err := state.writeEpoch(state.bootID); err != nil {
+			// Rebind the epoch to whatever the checkpoint is now, after reconcile has
+			// read the previous one and possibly discarded.
+			current := newCheckpoint()
+			if err := state.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, current); err != nil {
+				return nil, fmt.Errorf("unable to sync from checkpoint: %v", err)
+			}
+			if err := state.writeEpoch(current.Checksum); err != nil {
 				return nil, err
 			}
 			return state, nil
 		}
 	}
 
-	checkpoint := newCheckpoint()
-	if err := state.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
+	if err := state.saveCheckpoint(newCheckpoint()); err != nil {
 		return nil, fmt.Errorf("unable to sync to checkpoint: %v", err)
-	}
-	if err := state.writeEpoch(state.bootID); err != nil {
-		return nil, err
 	}
 
 	return state, nil
@@ -243,6 +291,11 @@ func validatePreparedDevices(claimUID string, preparedDevices PreparedDevices) e
 		}
 		if pd.ContainerEdits == nil || pd.ContainerEdits.ContainerEdits == nil {
 			return fmt.Errorf("checkpoint entry for claim %s device %s has no container edits", claimUID, pd.DeviceName)
+		}
+		// Edits that grant no device node would rebuild into a spec that resolves but
+		// hands the container no GPU.
+		if len(pd.ContainerEdits.ContainerEdits.DeviceNodes) == 0 {
+			return fmt.Errorf("checkpoint entry for claim %s device %s grants no device nodes", claimUID, pd.DeviceName)
 		}
 		// A non-nil wrapper can still carry nil entries in its pointer slices; CDI
 		// dereferences these while determining the spec version, so a nil entry would
@@ -295,6 +348,10 @@ func (s *DeviceState) validateCheckpointedClaim(claimUID string, preparedDevices
 func (s *DeviceState) ensureClaimSpec(claimUID string, preparedDevices PreparedDevices) error {
 	if err := s.validateCheckpointedClaim(claimUID, preparedDevices); err != nil {
 		return err
+	}
+	// The response always names the common device, so that spec has to exist as well.
+	if err := s.cdi.CreateCommonSpecFile(); err != nil {
+		return fmt.Errorf("ensure common CDI spec for claim %s: %w", claimUID, err)
 	}
 	if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
 		return fmt.Errorf("ensure CDI spec for claim %s: %w", claimUID, err)
@@ -358,9 +415,17 @@ func (s *DeviceState) reconcileCDISpecs() error {
 	// kubelet still considers the claims prepared and will not call Prepare again, so
 	// discarding here would strand them with no spec to resolve. Cross-boot and
 	// cross-reload device identity still need the stable name tracked in #83.
-	stored := s.readStoredEpoch()
-	if stored != "" && s.bootID != "" && stored != s.bootID {
-		klog.Warningf("checkpoint boot epoch %q differs from current boot %q; discarding %d checkpointed claim(s) without replay", stored, s.bootID, len(checkpoint.V1.PreparedClaims))
+	stored, trusted := s.readStoredEpoch()
+	switch {
+	case !trusted || s.bootID == "":
+		// Nothing to compare against, so the checkpoint is kept and verified below.
+	case stored.Checkpoint != checkpoint.Checksum:
+		// The checkpoint was written after this epoch was recorded, so it describes
+		// claims some other binary prepared. A reboot cannot be attributed to them, and
+		// discarding would drop claims kubelet may hold from that later Prepare.
+		klog.Warningf("boot epoch describes checkpoint %d but the checkpoint is now %d; keeping it and verifying instead of discarding", stored.Checkpoint, checkpoint.Checksum)
+	case stored.BootID != s.bootID:
+		klog.Warningf("checkpoint boot epoch %q differs from current boot %q; discarding %d checkpointed claim(s) without replay", stored.BootID, s.bootID, len(checkpoint.V1.PreparedClaims))
 		return s.discardCheckpoint(checkpoint.V1.PreparedClaims)
 	}
 
@@ -373,7 +438,7 @@ func (s *DeviceState) reconcileCDISpecs() error {
 	// the wrong numbers, or silently dropping a claim kubelet still holds, are both worse
 	// than refusing to start and letting an operator drain or restart kubelet.
 	if !s.deviceNodesCurrent(checkpoint.V1.PreparedClaims) {
-		return fmt.Errorf("checkpointed device nodes no longer match the host and the boot epoch (stored %q, current %q) does not confirm a reboot; refusing to discard %d claim(s) kubelet may still consider prepared", stored, s.bootID, len(checkpoint.V1.PreparedClaims))
+		return fmt.Errorf("checkpointed device nodes no longer match the host and the boot epoch (stored %q, current %q) does not confirm a reboot; refusing to discard %d claim(s) kubelet may still consider prepared", stored.BootID, s.bootID, len(checkpoint.V1.PreparedClaims))
 	}
 
 	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {
@@ -385,6 +450,12 @@ func (s *DeviceState) reconcileCDISpecs() error {
 			// the type-aware, stable identity tracked in #83 and #86; until then the
 			// claim stays unusable and this only avoids making it worse.
 			klog.Warningf("skipping unrecoverable checkpoint entry for claim %s: %v", claimUID, err)
+			// Leaving the old spec behind on a persistent spec directory would let the
+			// runtime keep resolving the claim to device nodes that may now belong to
+			// another GPU, so remove it rather than only declining to rebuild it.
+			if rmErr := s.cdi.DeleteClaimSpecFile(claimUID); rmErr != nil {
+				return fmt.Errorf("unable to remove the spec for unrecoverable claim %s: %w", claimUID, rmErr)
+			}
 			continue
 		}
 		if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
@@ -436,7 +507,7 @@ func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Devi
 	}
 
 	preparedClaims[claimUID] = preparedDevices
-	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
+	if err := s.saveCheckpoint(checkpoint); err != nil {
 		return nil, fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 
@@ -460,6 +531,12 @@ func (s *DeviceState) Unprepare(claimUID string) error {
 		return nil
 	}
 
+	// Startup validates the checkpoint, but Unprepare is reached again on every claim
+	// teardown, so a malformed entry would otherwise be dereferenced here instead.
+	if err := validatePreparedDevices(claimUID, preparedClaims[claimUID]); err != nil {
+		return fmt.Errorf("cannot unprepare claim %s: %w", claimUID, err)
+	}
+
 	if err := s.unprepareDevices(claimUID, preparedClaims[claimUID]); err != nil {
 		return fmt.Errorf("unprepare failed: %v", err)
 	}
@@ -470,7 +547,7 @@ func (s *DeviceState) Unprepare(claimUID string) error {
 	}
 
 	delete(preparedClaims, claimUID)
-	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
+	if err := s.saveCheckpoint(checkpoint); err != nil {
 		return fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 
@@ -642,6 +719,11 @@ func (s *DeviceState) unprepareDevices(claimUID string, devices PreparedDevices)
 	for _, device := range devices {
 		allocDev, exists := s.allocatable[device.DeviceName]
 		if !exists {
+			// Reporting success here would tell kubelet the device was cleaned up while
+			// its host state, including a driver binding left by a VFIO conversion, is
+			// whatever the last Prepare made it. Surface it instead of releasing the
+			// claim on an unverifiable cleanup.
+			errs = append(errs, fmt.Errorf("device %s is no longer in the inventory, so its host state cannot be restored", device.DeviceName))
 			continue
 		}
 		if allocDev.Type() == consts.VfioDeviceType && allocDev.Vfio != nil && s.vfioManager != nil {

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -296,6 +296,35 @@ func (s *DeviceState) ensureClaimSpec(claimUID string, preparedDevices PreparedD
 	return nil
 }
 
+// deviceNodesCurrent reports whether every checkpointed device node still resolves to
+// the major/minor it was prepared with. The boot epoch catches a reboot; this catches a
+// same-boot change that moves a node's numbers without changing the boot id, for example
+// /dev/kfd's dynamically allocated major after a KFD reload, or a node whose path no
+// longer exists. It does NOT catch a node that keeps the same numbers but now backs a
+// different physical GPU (the DRM card/render minors are stable per path), which needs
+// the stable identity tracked in #83. Malformed entries (nil device, nil wrapper, nil
+// node) are left to validateCheckpointedClaim; this skips them.
+func (s *DeviceState) deviceNodesCurrent(claims PreparedClaims) bool {
+	for _, preparedDevices := range claims {
+		for _, pd := range preparedDevices {
+			if pd == nil || pd.ContainerEdits == nil || pd.ContainerEdits.ContainerEdits == nil {
+				continue
+			}
+			for _, n := range pd.ContainerEdits.ContainerEdits.DeviceNodes {
+				if n == nil || n.HostPath == "" || (n.Major == 0 && n.Minor == 0) {
+					continue
+				}
+				major, minor, _, _, err := getDeviceAttrs(n.HostPath)
+				if err != nil || major != n.Major || minor != n.Minor {
+					klog.Warningf("checkpointed device node %s resolves to %d:%d now, recorded %d:%d (err=%v); the checkpoint is stale", n.HostPath, major, minor, n.Major, n.Minor, err)
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
 // reconcileCDISpecs rebuilds the per-claim CDI spec files from the checkpoint on a
 // plugin restart, which can clear the (often tmpfs) spec directory while the
 // checkpoint survives. Replay is gated on a boot epoch: a checkpoint from a different
@@ -323,6 +352,15 @@ func (s *DeviceState) reconcileCDISpecs() error {
 	stored := s.readStoredEpoch()
 	if s.bootID == "" || stored == "" || stored != s.bootID {
 		klog.Warningf("checkpoint boot epoch %q does not match current %q; discarding %d checkpointed claim(s) without replay", stored, s.bootID, len(checkpoint.V1.PreparedClaims))
+		return s.discardCheckpoint(checkpoint.V1.PreparedClaims)
+	}
+
+	// Same boot, but a driver reload can still renumber a device node, or remove it,
+	// without changing the boot id. If any checkpointed node no longer matches the host,
+	// the edits are stale, so discard instead of rebuilding a spec that points at the
+	// wrong numbers.
+	if !s.deviceNodesCurrent(checkpoint.V1.PreparedClaims) {
+		klog.Warningf("checkpointed device nodes no longer match the host; discarding %d claim(s) without replay", len(checkpoint.V1.PreparedClaims))
 		return s.discardCheckpoint(checkpoint.V1.PreparedClaims)
 	}
 

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -33,11 +33,13 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -151,9 +153,23 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 	return state, nil
 }
 
-// validatePreparedDevices rejects a checkpoint entry that cannot be turned into a
-// CDI spec, so a corrupt or partial checkpoint fails the claim loudly rather than
-// panicking at startup or reporting a claim as prepared when it is not.
+// loadCheckpoint reads the checkpoint and readies it for use, so callers can index its map.
+func (s *DeviceState) loadCheckpoint() (*Checkpoint, error) {
+	checkpoint := newCheckpoint()
+	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
+		return nil, fmt.Errorf("unable to sync from checkpoint: %v", err)
+	}
+	if checkpoint.V1 == nil {
+		return nil, fmt.Errorf("checkpoint has no v1 payload")
+	}
+	if checkpoint.V1.PreparedClaims == nil {
+		// "preparedClaims": null decodes to a nil map, which Prepare cannot assign into.
+		checkpoint.V1.PreparedClaims = make(PreparedClaims)
+	}
+	return checkpoint, nil
+}
+
+// validatePreparedDevices rejects a checkpoint entry that cannot become a CDI spec.
 func validatePreparedDevices(claimUID string, preparedDevices PreparedDevices) error {
 	if len(preparedDevices) == 0 {
 		return fmt.Errorf("checkpoint entry for claim %s has no prepared devices", claimUID)
@@ -168,54 +184,62 @@ func validatePreparedDevices(claimUID string, preparedDevices PreparedDevices) e
 		if pd.ContainerEdits == nil || pd.ContainerEdits.ContainerEdits == nil {
 			return fmt.Errorf("checkpoint entry for claim %s device %s has no container edits", claimUID, pd.DeviceName)
 		}
-		// Edits that grant no device node would rebuild into a spec that resolves but
-		// hands the container no GPU.
-		if len(pd.ContainerEdits.ContainerEdits.DeviceNodes) == 0 {
+		edits := pd.ContainerEdits.ContainerEdits
+		if len(edits.DeviceNodes) == 0 {
 			return fmt.Errorf("checkpoint entry for claim %s device %s grants no device nodes", claimUID, pd.DeviceName)
 		}
-		// A non-nil wrapper can still carry nil entries in its pointer slices; CDI
-		// dereferences these while determining the spec version, so a nil entry would
-		// panic before CreateClaimSpecFile could return a normal error.
-		edits := pd.ContainerEdits.ContainerEdits
-		for i, n := range edits.DeviceNodes {
-			if n == nil {
-				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil deviceNodes[%d]", claimUID, pd.DeviceName, i)
-			}
+		// CDI dereferences these entries before it validates them, so a nil one panics.
+		if i := slices.Index(edits.DeviceNodes, nil); i >= 0 {
+			return fmt.Errorf("checkpoint entry for claim %s device %s has a nil deviceNodes[%d]", claimUID, pd.DeviceName, i)
 		}
-		for i, h := range edits.Hooks {
-			if h == nil {
-				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil hooks[%d]", claimUID, pd.DeviceName, i)
-			}
+		if i := slices.Index(edits.Hooks, nil); i >= 0 {
+			return fmt.Errorf("checkpoint entry for claim %s device %s has a nil hooks[%d]", claimUID, pd.DeviceName, i)
 		}
-		for i, m := range edits.Mounts {
-			if m == nil {
-				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil mounts[%d]", claimUID, pd.DeviceName, i)
-			}
+		if i := slices.Index(edits.Mounts, nil); i >= 0 {
+			return fmt.Errorf("checkpoint entry for claim %s device %s has a nil mounts[%d]", claimUID, pd.DeviceName, i)
 		}
-		for i, nd := range edits.NetDevices {
-			if nd == nil {
-				return fmt.Errorf("checkpoint entry for claim %s device %s has a nil netDevices[%d]", claimUID, pd.DeviceName, i)
+		if i := slices.Index(edits.NetDevices, nil); i >= 0 {
+			return fmt.Errorf("checkpoint entry for claim %s device %s has a nil netDevices[%d]", claimUID, pd.DeviceName, i)
+		}
+	}
+	return nil
+}
+
+// deviceNodesCurrent reports whether every device node of a validated entry still resolves
+// on the host with the recorded type and numbers. Unchanged numbers do not prove the node
+// still backs the same GPU; that needs the stable identity tracked in #83.
+func deviceNodesCurrent(preparedDevices PreparedDevices) error {
+	for _, pd := range preparedDevices {
+		for _, n := range pd.ContainerEdits.DeviceNodes {
+			// CDI lets a node carry only Path, and the VFIO path emits exactly that.
+			hostPath := cmp.Or(n.HostPath, n.Path)
+			if hostPath == "" {
+				continue
+			}
+			major, minor, devType, _, err := getDeviceAttrs(hostPath)
+			if err != nil {
+				return fmt.Errorf("device node %s no longer resolves: %w", hostPath, err)
+			}
+			if n.Type != "" && n.Type != devType {
+				return fmt.Errorf("device node %s is type %q now, recorded %q", hostPath, devType, n.Type)
+			}
+			if (n.Major != 0 || n.Minor != 0) && (major != n.Major || minor != n.Minor) {
+				return fmt.Errorf("device node %s is %d:%d now, recorded %d:%d", hostPath, major, minor, n.Major, n.Minor)
 			}
 		}
 	}
 	return nil
 }
 
-// validateCheckpointedClaim rejects a checkpoint entry that cannot be safely turned
-// into a CDI spec: one that is structurally corrupt, or that names a device not in
-// the current allocatable inventory (removed, repartitioned, or skipped by discovery
-// this boot). The name match is necessary but not sufficient; proving it is the same
-// physical GPU needs the stable identity tracked in #83.
-func (s *DeviceState) validateCheckpointedClaim(claimUID string, preparedDevices PreparedDevices) error {
+// validateCheckpointEntry reports whether an entry can be rebuilt into the spec it came from.
+func validateCheckpointEntry(claimUID string, preparedDevices PreparedDevices) error {
 	if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
 		return err
 	}
-	return s.claimDevicesAllocatable(claimUID, preparedDevices)
+	return deviceNodesCurrent(preparedDevices)
 }
 
-// claimDevicesAllocatable reports whether discovery currently offers every device the
-// claim was prepared with. Absence is not proof the claim is dead: discovery can be
-// incomplete, and an on-demand VFIO conversion returns the device under another name.
+// claimDevicesAllocatable reports whether discovery currently offers every device of the claim.
 func (s *DeviceState) claimDevicesAllocatable(claimUID string, preparedDevices PreparedDevices) error {
 	for _, pd := range preparedDevices {
 		if _, ok := s.allocatable[pd.DeviceName]; !ok {
@@ -225,112 +249,60 @@ func (s *DeviceState) claimDevicesAllocatable(claimUID string, preparedDevices P
 	return nil
 }
 
-// ensureClaimSpec makes sure the CDI spec for a checkpointed claim exists, so a
-// claim reported as prepared from the checkpoint is actually usable. It is safe to
-// call repeatedly: CreateClaimSpecFile overwrites the deterministic spec path.
+// ensureClaimSpec rewrites the CDI spec of a checkpointed claim, so a checkpoint hit never
+// reports a claim as prepared while its spec is missing from a cleared spec directory.
 func (s *DeviceState) ensureClaimSpec(claimUID string, preparedDevices PreparedDevices) error {
-	if err := s.validateCheckpointedClaim(claimUID, preparedDevices); err != nil {
+	if err := validateCheckpointEntry(claimUID, preparedDevices); err != nil {
+		return fmt.Errorf("claim %s cannot be prepared from its checkpoint entry (recreate the pod): %w", claimUID, err)
+	}
+	if err := s.claimDevicesAllocatable(claimUID, preparedDevices); err != nil {
 		return err
 	}
-	// The response always names the common device, so that spec has to exist as well.
+	// The response names the common device too, so that spec has to exist as well.
 	if err := s.cdi.CreateCommonSpecFile(); err != nil {
-		return fmt.Errorf("ensure common CDI spec for claim %s: %w", claimUID, err)
+		return fmt.Errorf("unable to ensure the common CDI spec for claim %s: %w", claimUID, err)
 	}
 	if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
-		return fmt.Errorf("ensure CDI spec for claim %s: %w", claimUID, err)
+		return fmt.Errorf("unable to ensure the CDI spec for claim %s: %w", claimUID, err)
 	}
 	return nil
 }
 
-// deviceNodesCurrent reports whether every checkpointed device node still resolves on the
-// host. It is the only check that the checkpoint still describes this machine, so a node
-// that cannot be stat'd, changed type, or moved to different numbers fails it. CDI lets a
-// node carry only a path, with the host path defaulting to Path and the numbers resolved
-// by the runtime, and the VFIO path emits exactly that, so those are verified by path
-// rather than skipped. It does NOT catch a node that keeps its numbers but now backs a
-// different GPU, which needs the stable identity tracked in #83.
-func (s *DeviceState) deviceNodesCurrent(claims PreparedClaims) bool {
-	for _, preparedDevices := range claims {
-		for _, pd := range preparedDevices {
-			if pd == nil || pd.ContainerEdits == nil || pd.ContainerEdits.ContainerEdits == nil {
-				continue
-			}
-			for _, n := range pd.ContainerEdits.ContainerEdits.DeviceNodes {
-				if n == nil {
-					continue
-				}
-				hostPath := n.HostPath
-				if hostPath == "" {
-					hostPath = n.Path
-				}
-				if hostPath == "" {
-					continue
-				}
-				major, minor, devType, _, err := getDeviceAttrs(hostPath)
-				if err != nil {
-					klog.Warningf("checkpointed device node %s no longer resolves (%v); the checkpoint is stale", hostPath, err)
-					return false
-				}
-				if n.Type != "" && n.Type != devType {
-					klog.Warningf("checkpointed device node %s is type %q now, recorded %q; the checkpoint is stale", hostPath, devType, n.Type)
-					return false
-				}
-				if (n.Major != 0 || n.Minor != 0) && (major != n.Major || minor != n.Minor) {
-					klog.Warningf("checkpointed device node %s resolves to %d:%d now, recorded %d:%d; the checkpoint is stale", hostPath, major, minor, n.Major, n.Minor)
-					return false
-				}
-			}
-		}
-	}
-	return true
-}
-
-// reconcileCDISpecs rebuilds the per-claim CDI spec files from the checkpoint on a
-// plugin restart, which can clear the (often tmpfs) spec directory while the
-// checkpoint survives. Startup fails when a checkpointed device node no longer resolves,
-// because deleting state kubelet still holds prepared would strand the claim. A malformed
-// entry loses its stale spec; one whose device is merely absent from the inventory keeps
-// it, since absence can be incomplete discovery or an on-demand VFIO rename. A CDI write
-// error fails startup, because the kubelet may not re-Prepare an already-prepared claim.
+// reconcileCDISpecs rebuilds the per-claim CDI specs from the checkpoint at startup, because
+// a restart can clear the (usually tmpfs) spec directory while the checkpoint survives.
+//
+// Entries are never dropped here. A running kubelet does not Prepare a claim it already
+// prepared, so the entry is all a later Unprepare has to go on; after a reboot kubelet does
+// Prepare again, and an entry that can no longer be rebuilt then fails that Prepare rather
+// than being replayed. Such an entry loses only its spec.
 func (s *DeviceState) reconcileCDISpecs() error {
-	checkpoint := newCheckpoint()
-	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
-		return fmt.Errorf("unable to sync from checkpoint: %v", err)
+	checkpoint, err := s.loadCheckpoint()
+	if err != nil {
+		return err
 	}
-	if checkpoint.V1 == nil {
-		return fmt.Errorf("checkpoint has no v1 payload")
-	}
-
-	// Nothing here removes checkpointed state. kubelet does not call Prepare again for a
-	// claim it still considers prepared, so dropping one would strand it, and telling
-	// this boot apart from the one the claims were prepared in needs the stable identity
-	// in #83. Rebuild what still matches the host and refuse to start otherwise.
-	if !s.deviceNodesCurrent(checkpoint.V1.PreparedClaims) {
-		return fmt.Errorf("checkpointed device nodes no longer match the host; refusing to serve %d claim(s) kubelet may still consider prepared", len(checkpoint.V1.PreparedClaims))
-	}
-
 	for claimUID, preparedDevices := range checkpoint.V1.PreparedClaims {
-		if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
-			// Content this malformed can never be rebuilt into a spec, so drop the
-			// authorization the old one still grants.
-			klog.Warningf("removing the spec for malformed checkpoint entry %s: %v", claimUID, err)
-			if rmErr := s.cdi.DeleteClaimSpecFile(claimUID); rmErr != nil {
-				return fmt.Errorf("unable to remove the spec for malformed claim %s: %w", claimUID, rmErr)
+		if err := validateCheckpointEntry(claimUID, preparedDevices); err != nil {
+			klog.Warningf("Removing the CDI spec for claim %s, whose checkpoint entry can no longer be rebuilt: %v", claimUID, err)
+			if err := s.cdi.DeleteClaimSpecFile(claimUID); err != nil {
+				return fmt.Errorf("unable to remove the CDI spec for claim %s: %w", claimUID, err)
 			}
 			continue
 		}
 		if err := s.claimDevicesAllocatable(claimUID, preparedDevices); err != nil {
-			// deviceNodesCurrent already proved the nodes resolve, so an existing spec is
-			// no less valid than before this start; an on-demand VFIO device lands here.
-			klog.Warningf("leaving the spec for claim %s in place: %v", claimUID, err)
+			// The nodes resolve, so an existing spec is as good as before; discovery may
+			// be incomplete, or an on-demand VFIO conversion renamed the device.
+			klog.Warningf("Leaving the CDI spec for claim %s as is: %v", claimUID, err)
 			continue
 		}
 		if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
-			// A CDI write or filesystem error is not self-healing: the kubelet may keep
-			// the claim marked prepared and never call Prepare again, so fail startup
-			// loudly instead of registering with a missing spec.
-			return fmt.Errorf("rebuild CDI spec for claim %s on startup: %w", claimUID, err)
+			// Not self-healing: kubelet may never Prepare this claim again.
+			return fmt.Errorf("unable to rebuild the CDI spec for claim %s: %w", claimUID, err)
 		}
+		names := make([]string, 0, len(preparedDevices))
+		for _, pd := range preparedDevices {
+			names = append(names, pd.DeviceName)
+		}
+		klog.Infof("Rebuilt the CDI spec for checkpointed claim %s: %s", claimUID, strings.Join(names, ", "))
 	}
 	return nil
 }
@@ -341,23 +313,14 @@ func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Devi
 
 	claimUID := string(claim.UID)
 
-	checkpoint := newCheckpoint()
-	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
-		return nil, fmt.Errorf("unable to sync from checkpoint: %v", err)
-	}
-	if checkpoint.V1 == nil {
-		return nil, fmt.Errorf("checkpoint has no v1 payload")
-	}
-	if checkpoint.V1.PreparedClaims == nil {
-		// An explicit "preparedClaims": null decodes to a nil map; initialize it so the
-		// assignment below does not panic.
-		checkpoint.V1.PreparedClaims = make(PreparedClaims)
+	checkpoint, err := s.loadCheckpoint()
+	if err != nil {
+		return nil, err
 	}
 	preparedClaims := checkpoint.V1.PreparedClaims
 
 	if preparedDevices := preparedClaims[claimUID]; preparedDevices != nil {
-		// The spec directory can be cleared (tmpfs) while the checkpoint survives, so
-		// make sure the spec exists before reporting the claim as already prepared.
+		// The spec directory may have been cleared since the claim was prepared.
 		if err := s.ensureClaimSpec(claimUID, preparedDevices); err != nil {
 			return nil, err
 		}
@@ -385,31 +348,25 @@ func (s *DeviceState) Unprepare(claimUID string) error {
 	s.Lock()
 	defer s.Unlock()
 
-	checkpoint := newCheckpoint()
-	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
-		return fmt.Errorf("unable to sync from checkpoint: %v", err)
-	}
-	if checkpoint.V1 == nil {
-		return fmt.Errorf("checkpoint has no v1 payload")
+	checkpoint, err := s.loadCheckpoint()
+	if err != nil {
+		return err
 	}
 	preparedClaims := checkpoint.V1.PreparedClaims
 
-	if preparedClaims[claimUID] == nil {
+	preparedDevices := preparedClaims[claimUID]
+	if preparedDevices == nil {
 		return nil
 	}
 
-	// Startup validates the checkpoint, but Unprepare is reached again on every claim
-	// teardown, so a malformed entry would otherwise be dereferenced here instead.
-	if err := validatePreparedDevices(claimUID, preparedClaims[claimUID]); err != nil {
-		return fmt.Errorf("cannot unprepare claim %s: %w", claimUID, err)
-	}
-
-	if err := s.unprepareDevices(claimUID, preparedClaims[claimUID]); err != nil {
+	// Teardown has to be able to finish, so a malformed entry is dropped rather than kept.
+	if err := validatePreparedDevices(claimUID, preparedDevices); err != nil {
+		klog.Warningf("Dropping malformed checkpoint entry %s on unprepare: %v", claimUID, err)
+	} else if err := s.unprepareDevices(claimUID, preparedDevices); err != nil {
 		return fmt.Errorf("unprepare failed: %v", err)
 	}
 
-	err := s.cdi.DeleteClaimSpecFile(claimUID)
-	if err != nil {
+	if err := s.cdi.DeleteClaimSpecFile(claimUID); err != nil {
 		return fmt.Errorf("unable to delete CDI spec file for claim: %v", err)
 	}
 
@@ -586,11 +543,8 @@ func (s *DeviceState) unprepareDevices(claimUID string, devices PreparedDevices)
 	for _, device := range devices {
 		allocDev, exists := s.allocatable[device.DeviceName]
 		if !exists {
-			// Reporting success here would tell kubelet the device was cleaned up while
-			// its host state, including a driver binding left by a VFIO conversion, is
-			// whatever the last Prepare made it. Surface it instead of releasing the
-			// claim on an unverifiable cleanup.
-			errs = append(errs, fmt.Errorf("device %s is no longer in the inventory, so its host state cannot be restored", device.DeviceName))
+			// Nothing to restore against; a VFIO binding left behind is #94.
+			klog.Warningf("Device %s of claim %s is no longer in the inventory; its host state is left as is", device.DeviceName, claimUID)
 			continue
 		}
 		if allocDev.Type() == consts.VfioDeviceType && allocDev.Vfio != nil && s.vfioManager != nil {

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -388,6 +388,30 @@ func TestReconcileSkipsDeviceNotAllocatable(t *testing.T) {
 	require.Empty(t, after, "a device absent from the current inventory must not be rebuilt")
 }
 
+// Absence from the inventory is not proof the claim is dead: discovery can still be
+// incomplete, and an on-demand VFIO conversion returns the device under another name.
+// A spec that is already on disk keeps working, so reconcile must leave it alone.
+func TestReconcileKeepsExistingSpecWhenDeviceAbsentFromInventory(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm) // gpu-0-128 is deliberately absent from allocatable
+
+	const claimUID = "claim-uid-1"
+	require.NoError(t, s.cdi.CreateClaimSpecFile(claimUID, kfdDevices()))
+	before, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.NotEmpty(t, before, "the spec under test has to exist before reconcile runs")
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Len(t, after, len(before), "an absent device must not cost the claim a spec that still resolves")
+}
+
 // A checkpoint with a nested nil device node passes the wrapper checks; reconcile
 // must reject it rather than dereference it into a startup panic.
 func TestReconcileRejectsNestedNullDeviceNode(t *testing.T) {

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -178,8 +178,28 @@ func testDeviceState(t *testing.T, cache *cdiapi.Cache, cm checkpointmanager.Che
 		pluginPath:        t.TempDir(),
 		bootID:            "test-boot",
 	}
-	require.NoError(t, s.writeEpoch("test-boot"))
 	return s
+}
+
+// bindEpoch records an epoch for the checkpoint currently on disk, the way a real
+// checkpoint write does, so reconcile sees an epoch that describes it.
+func bindEpoch(t *testing.T, s *DeviceState) {
+	t.Helper()
+	cp := newCheckpoint()
+	require.NoError(t, s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, cp))
+	require.NoError(t, s.writeEpoch(cp.Checksum))
+}
+
+// bindEpochForBoot records an epoch describing the current checkpoint but under another
+// boot, which is the confirmed-reboot case.
+func bindEpochForBoot(t *testing.T, s *DeviceState, bootID string) {
+	t.Helper()
+	cp := newCheckpoint()
+	require.NoError(t, s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, cp))
+	saved := s.bootID
+	s.bootID = bootID
+	require.NoError(t, s.writeEpoch(cp.Checksum))
+	s.bootID = saved
 }
 
 // kfdDevices is a well-formed single-device claim naming gpu-0-128. Its node points at
@@ -238,6 +258,7 @@ func TestReconcileCDISpecs(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	before, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
@@ -255,24 +276,38 @@ func TestReconcileCDISpecs(t *testing.T) {
 }
 
 func TestValidatePreparedDevices(t *testing.T) {
-	edits := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}
-	valid := PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: edits}}
+	node := func() []*cdispec.DeviceNode {
+		return []*cdispec.DeviceNode{{Path: "/dev/kfd", HostPath: "/dev/kfd", Type: "c", Major: 1, Minor: 3}}
+	}
+	editsWith := func(mutate func(*cdispec.ContainerEdits)) *cdiapi.ContainerEdits {
+		e := &cdispec.ContainerEdits{DeviceNodes: node()}
+		if mutate != nil {
+			mutate(e)
+		}
+		return &cdiapi.ContainerEdits{ContainerEdits: e}
+	}
+
+	valid := PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: editsWith(nil)}}
 	require.NoError(t, validatePreparedDevices("uid", valid))
 
-	nilNode := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{DeviceNodes: []*cdispec.DeviceNode{nil}}}
-	nilHook := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{Hooks: []*cdispec.Hook{nil}}}
-	nilMount := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{Mounts: []*cdispec.Mount{nil}}}
-	nilNet := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{NetDevices: []*cdispec.LinuxNetDevice{nil}}}
-
+	// Each bad case keeps an otherwise usable edit set, so it fails on its own defect
+	// rather than on a shared missing field.
 	bad := map[string]PreparedDevices{
 		"empty":               {},
 		"nil device":          {nil},
-		"no device name":      {{Device: drapbv1.Device{}, ContainerEdits: edits}},
+		"no device name":      {{Device: drapbv1.Device{}, ContainerEdits: editsWith(nil)}},
 		"nil container edits": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}}},
-		"nil deviceNode":      {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilNode}},
-		"nil hook":            {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilHook}},
-		"nil mount":           {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilMount}},
-		"nil netDevice":       {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilNet}},
+		"hollow edits":        {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{}}},
+		"no device nodes": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}}},
+		"nil deviceNode": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.DeviceNodes = append(e.DeviceNodes, nil) })}},
+		"nil hook": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.Hooks = []*cdispec.Hook{nil} })}},
+		"nil mount": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.Mounts = []*cdispec.Mount{nil} })}},
+		"nil netDevice": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.NetDevices = []*cdispec.LinuxNetDevice{nil} })}},
 	}
 	for name, pds := range bad {
 		t.Run(name, func(t *testing.T) {
@@ -291,6 +326,7 @@ func TestPrepareRepairsMissingCheckpointedSpec(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	before, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
@@ -315,6 +351,7 @@ func TestReconcileSkipsMalformedCheckpointEntry(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -335,6 +372,7 @@ func TestPrepareRejectsMalformedCheckpointEntry(t *testing.T) {
 		{Device: drapbv1.Device{DeviceName: ""}, ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}},
 	}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}}
 	_, err := s.Prepare(claim)
@@ -352,6 +390,7 @@ func TestReconcileRejectsHollowContainerEdits(t *testing.T) {
 		{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{}},
 	}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -365,11 +404,11 @@ func TestReconcileRejectsHollowContainerEdits(t *testing.T) {
 func TestReconcileDiscardsCheckpointFromDifferentBoot(t *testing.T) {
 	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm, "gpu-0-128")
-	require.NoError(t, s.writeEpoch("boot-previous")) // stored epoch now differs from s.bootID
 
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpochForBoot(t, s, "boot-previous") // same checkpoint, earlier boot
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -391,6 +430,7 @@ func TestReconcileSkipsDeviceNotAllocatable(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -410,6 +450,7 @@ func TestReconcileRejectsNestedNullDeviceNode(t *testing.T) {
 		{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{DeviceNodes: []*cdispec.DeviceNode{nil}}}},
 	}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs()) // must not panic
 
@@ -436,6 +477,7 @@ func TestReconcileRebuildsWithoutConfirmedRebootWhenNodesMatch(t *testing.T) {
 		checkpoint := newCheckpoint()
 		checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
 		require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+		bindEpoch(t, s)
 
 		require.NoError(t, s.reconcileCDISpecs())
 
@@ -457,10 +499,10 @@ func TestReconcileRebuildsWithoutConfirmedRebootWhenNodesMatch(t *testing.T) {
 			pluginPath:        t.TempDir(),
 			bootID:            "", // procfs unreadable
 		}
-		require.NoError(t, s.writeEpoch("")) // stored epoch also empty
 		checkpoint := newCheckpoint()
 		checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
 		require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+		bindEpoch(t, s)
 
 		require.NoError(t, s.reconcileCDISpecs())
 
@@ -481,6 +523,7 @@ func TestReconcileQuarantinesBadClaimButRebuildsGood(t *testing.T) {
 	checkpoint.V1.PreparedClaims["good"] = kfdDevices()
 	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil} // malformed -> skipped
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -503,6 +546,7 @@ func TestReconcileFailsLoudOnCDIWriteError(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	// Force WriteSpec to fail deterministically and independently of file permissions
 	// (which root ignores) by planting a directory where the spec file must be written.
@@ -529,8 +573,7 @@ func TestReconcileDiscardDeletesStaleSpecs(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-
-	require.NoError(t, s.writeEpoch("boot-previous")) // force a cross-boot discard
+	bindEpochForBoot(t, s, "boot-previous") // force a cross-boot discard
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -561,6 +604,7 @@ func TestReconcileFailsStartupOnDeviceNodeRenumber(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = stale
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	require.Error(t, s.reconcileCDISpecs(), "a same-boot renumber must fail startup, not discard")
 
@@ -590,6 +634,7 @@ func TestReconcileFailsStartupOnMissingDeviceNode(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = gone
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
 
 	require.Error(t, s.reconcileCDISpecs(), "a missing node without a confirmed reboot must fail startup")
 
@@ -600,4 +645,66 @@ func TestReconcileFailsStartupOnMissingDeviceNode(t *testing.T) {
 	reloaded := newCheckpoint()
 	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
 	require.NotEmpty(t, reloaded.V1.PreparedClaims, "startup must fail without discarding the checkpoint")
+}
+
+// A reboot only authorizes a discard when nothing wrote the checkpoint after the epoch
+// was recorded. If an older binary prepared claims in between, the epoch describes a
+// different checkpoint, and discarding would drop claims kubelet may now hold.
+func TestReconcileKeepsCheckpointWrittenAfterTheEpoch(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	// Epoch recorded under an earlier boot, for an empty checkpoint.
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, newCheckpoint()))
+	bindEpochForBoot(t, s, "boot-previous")
+
+	// Another binary then prepares a claim, so the checkpoint no longer matches.
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.Contains(t, reloaded.V1.PreparedClaims, "claim-uid-1",
+		"a claim prepared after the epoch was recorded must not be discarded on a boot change")
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.NotEmpty(t, after, "its CDI spec must be rebuilt rather than deleted")
+}
+
+// Unprepare is reached again on every teardown, so a malformed checkpoint entry must be
+// rejected there rather than dereferenced.
+func TestUnprepareRejectsMalformedEntryWithoutPanic(t *testing.T) {
+	_, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm)
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
+
+	var err error
+	require.NotPanics(t, func() { err = s.Unprepare("bad") })
+	require.Error(t, err, "a malformed entry must fail unprepare, not be dereferenced")
+}
+
+// Reporting success for a device that is no longer in the inventory would tell kubelet
+// the host state was restored when it cannot have been.
+func TestUnprepareRejectsDeviceMissingFromInventory(t *testing.T) {
+	_, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm) // nothing allocatable
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["c"] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	bindEpoch(t, s)
+
+	require.Error(t, s.Unprepare("c"))
+
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.Contains(t, reloaded.V1.PreparedClaims, "c", "a failed unprepare must not drop the claim")
 }

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -153,6 +153,49 @@ func TestUnprepareDevices_PreDiscoveredVfioNotRestored(t *testing.T) {
 	assert.Nil(t, allocDev.AmdGpu, "should not gain an AmdGpu entry")
 }
 
+func newCacheAndCheckpointer(t *testing.T) (string, *cdiapi.Cache, checkpointmanager.CheckpointManager) {
+	t.Helper()
+	cdiRoot := t.TempDir()
+	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
+	require.NoError(t, err)
+	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
+	require.NoError(t, err)
+	return cdiRoot, cache, cm
+}
+
+// testDeviceState wires a DeviceState with a temp plugin dir, a matching boot epoch,
+// and the named allocatable devices, so reconcile replays instead of discarding.
+func testDeviceState(t *testing.T, cache *cdiapi.Cache, cm checkpointmanager.CheckpointManager, devices ...string) *DeviceState {
+	t.Helper()
+	alloc := AllocatableDevices{}
+	for _, d := range devices {
+		alloc[d] = &AllocatableDevice{}
+	}
+	s := &DeviceState{
+		cdi:               &CDIHandler{cache: cache},
+		allocatable:       alloc,
+		checkpointManager: cm,
+		pluginPath:        t.TempDir(),
+		bootID:            "test-boot",
+	}
+	require.NoError(t, s.writeEpoch("test-boot"))
+	return s
+}
+
+// kfdDevices is a well-formed single-device claim naming gpu-0-128 with a /dev/kfd node.
+func kfdDevices() PreparedDevices {
+	return PreparedDevices{
+		{
+			Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+				DeviceNodes: []*cdispec.DeviceNode{
+					{Path: "/dev/kfd", HostPath: "/dev/kfd", Type: "c", Major: 1, Minor: 1, Permissions: "rw"},
+				},
+			}},
+		},
+	}
+}
+
 func TestPreparedDevicesGetDevices(t *testing.T) {
 	tests := map[string]struct {
 		preparedDevices PreparedDevices
@@ -184,42 +227,29 @@ func TestPreparedDevicesGetDevices(t *testing.T) {
 	}
 }
 
+// Within the same boot, with the device still allocatable, reconcile rebuilds the
+// per-claim CDI spec from the checkpoint.
 func TestReconcileCDISpecs(t *testing.T) {
-	cdiRoot := t.TempDir()
-	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
-	assert.NoError(t, err)
-	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
-	assert.NoError(t, err)
-
-	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
 
 	checkpoint := newCheckpoint()
-	checkpoint.V1.PreparedClaims["claim-uid-1"] = PreparedDevices{
-		{
-			Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
-				DeviceNodes: []*cdispec.DeviceNode{
-					{Path: "/dev/kfd", HostPath: "/dev/kfd", Type: "c", Major: 1, Minor: 1, Permissions: "rw"},
-				},
-			}},
-		},
-	}
-	assert.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	// The spec dir starts empty, as a reboot leaves it.
 	before, err := os.ReadDir(cdiRoot)
-	assert.NoError(t, err)
-	assert.Empty(t, before)
+	require.NoError(t, err)
+	require.Empty(t, before)
 
-	assert.NoError(t, s.reconcileCDISpecs())
+	require.NoError(t, s.reconcileCDISpecs())
 
 	after, err := os.ReadDir(cdiRoot)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, after, "reconcile should rebuild the CDI spec from the checkpoint")
 
 	data, err := os.ReadFile(filepath.Join(cdiRoot, after[0].Name()))
-	assert.NoError(t, err)
-	assert.Contains(t, string(data), "/dev/kfd", "the rebuilt spec must carry the device node from the checkpoint")
+	require.NoError(t, err)
+	require.Contains(t, string(data), "/dev/kfd", "the rebuilt spec must carry the device node from the checkpoint")
 }
 
 func TestValidatePreparedDevices(t *testing.T) {
@@ -227,11 +257,20 @@ func TestValidatePreparedDevices(t *testing.T) {
 	valid := PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: edits}}
 	require.NoError(t, validatePreparedDevices("uid", valid))
 
+	nilNode := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{DeviceNodes: []*cdispec.DeviceNode{nil}}}
+	nilHook := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{Hooks: []*cdispec.Hook{nil}}}
+	nilMount := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{Mounts: []*cdispec.Mount{nil}}}
+	nilNet := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{NetDevices: []*cdispec.LinuxNetDevice{nil}}}
+
 	bad := map[string]PreparedDevices{
 		"empty":               {},
 		"nil device":          {nil},
 		"no device name":      {{Device: drapbv1.Device{}, ContainerEdits: edits}},
 		"nil container edits": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}}},
+		"nil deviceNode":      {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilNode}},
+		"nil hook":            {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilHook}},
+		"nil mount":           {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilMount}},
+		"nil netDevice":       {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: nilNet}},
 	}
 	for name, pds := range bad {
 		t.Run(name, func(t *testing.T) {
@@ -243,26 +282,12 @@ func TestValidatePreparedDevices(t *testing.T) {
 // A checkpoint-hit Prepare must recreate a spec that a tmpfs-clearing restart
 // removed, rather than reporting the claim as prepared with no spec on disk.
 func TestPrepareRepairsMissingCheckpointedSpec(t *testing.T) {
-	cdiRoot := t.TempDir()
-	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
-	require.NoError(t, err)
-	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
-	require.NoError(t, err)
-
-	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
 
 	const claimUID = "claim-uid-1"
 	checkpoint := newCheckpoint()
-	checkpoint.V1.PreparedClaims[claimUID] = PreparedDevices{
-		{
-			Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
-				DeviceNodes: []*cdispec.DeviceNode{
-					{Path: "/dev/kfd", HostPath: "/dev/kfd", Type: "c", Major: 1, Minor: 1, Permissions: "rw"},
-				},
-			}},
-		},
-	}
+	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
 	before, err := os.ReadDir(cdiRoot)
@@ -279,34 +304,28 @@ func TestPrepareRepairsMissingCheckpointedSpec(t *testing.T) {
 	require.NotEmpty(t, after, "a checkpoint-hit Prepare must recreate the missing CDI spec")
 }
 
-// A malformed checkpoint entry is logged and skipped at startup, not a panic.
+// A malformed checkpoint entry is logged and skipped at startup, not a panic, and
+// leaves no spec behind.
 func TestReconcileSkipsMalformedCheckpointEntry(t *testing.T) {
-	cdiRoot := t.TempDir()
-	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
-	require.NoError(t, err)
-	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
-	require.NoError(t, err)
-
-	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm)
 
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
 	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a malformed entry must be skipped, not written as a spec")
 }
 
 // A checkpoint-hit Prepare must fail closed on a malformed entry rather than
-// report the claim as prepared. A device with no name cannot become a CDI spec,
-// so Prepare has to return an error instead of the devices.
+// report the claim as prepared. A device with no name cannot become a CDI spec.
 func TestPrepareRejectsMalformedCheckpointEntry(t *testing.T) {
-	cdiRoot := t.TempDir()
-	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
-	require.NoError(t, err)
-	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
-	require.NoError(t, err)
-
-	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+	_, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm)
 
 	const claimUID = "claim-uid-1"
 	checkpoint := newCheckpoint()
@@ -316,21 +335,15 @@ func TestPrepareRejectsMalformedCheckpointEntry(t *testing.T) {
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
 	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}}
-	_, err = s.Prepare(claim)
+	_, err := s.Prepare(claim)
 	require.Error(t, err, "checkpoint-hit Prepare with a malformed entry must fail closed, not report success")
 }
 
-// A checkpoint entry whose container edits wrapper is present but hollow (nil
-// inner edits) must be rejected during reconciliation, not dereferenced into a
-// panic while rebuilding the CDI spec.
+// A non-nil but hollow ContainerEdits (nil inner edits) must be rejected during
+// reconciliation, not dereferenced into a panic, and must leave no spec behind.
 func TestReconcileRejectsHollowContainerEdits(t *testing.T) {
-	cdiRoot := t.TempDir()
-	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
-	require.NoError(t, err)
-	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
-	require.NoError(t, err)
-
-	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
 
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["hollow"] = PreparedDevices{
@@ -338,6 +351,184 @@ func TestReconcileRejectsHollowContainerEdits(t *testing.T) {
 	}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	// Must not panic; the malformed entry is logged and skipped.
 	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a hollow container-edits entry must not be written as a spec")
+}
+
+// A checkpoint written under a different boot must be discarded, not replayed: its
+// device nodes may now point at other hardware.
+func TestReconcileDiscardsCheckpointFromDifferentBoot(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+	require.NoError(t, s.writeEpoch("boot-previous")) // stored epoch now differs from s.bootID
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a checkpoint from a previous boot must not be replayed into a CDI spec")
+
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.Empty(t, reloaded.V1.PreparedClaims, "the stale checkpoint must be discarded")
+}
+
+// A checkpointed device that is no longer in the allocatable inventory (removed or
+// skipped by discovery this boot) must be quarantined, not rebuilt from the checkpoint.
+func TestReconcileSkipsDeviceNotAllocatable(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm) // gpu-0-128 is deliberately absent from allocatable
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a device absent from the current inventory must not be rebuilt")
+}
+
+// A checkpoint with a nested nil device node passes the wrapper checks; reconcile
+// must reject it rather than dereference it into a startup panic.
+func TestReconcileRejectsNestedNullDeviceNode(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["nested"] = PreparedDevices{
+		{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{DeviceNodes: []*cdispec.DeviceNode{nil}}}},
+	}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs()) // must not panic
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a nested nil device node must be rejected, not written as a spec")
+}
+
+// The boot epoch guard must fail closed, not open. A missing epoch file or an
+// unreadable boot id has to discard the checkpoint rather than replay it: guarding
+// only on inequality (stored != bootID) would replay when both are empty.
+func TestReconcileFailsClosedWithoutBootEpoch(t *testing.T) {
+	t.Run("epoch file missing", func(t *testing.T) {
+		cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+		s := &DeviceState{
+			cdi:               &CDIHandler{cache: cache},
+			allocatable:       AllocatableDevices{"gpu-0-128": &AllocatableDevice{}},
+			checkpointManager: cm,
+			pluginPath:        t.TempDir(), // no boot-epoch file written -> stored == ""
+			bootID:            "test-boot",
+		}
+		checkpoint := newCheckpoint()
+		checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
+		require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+		require.NoError(t, s.reconcileCDISpecs())
+
+		after, err := os.ReadDir(cdiRoot)
+		require.NoError(t, err)
+		require.Empty(t, after, "a checkpoint with no recorded boot epoch must not be replayed")
+	})
+
+	// Both the stored epoch and the current boot id are empty. The old inequality-only
+	// guard would see "" == "" and replay; the fail-closed guard must discard.
+	t.Run("boot id unreadable", func(t *testing.T) {
+		cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+		s := &DeviceState{
+			cdi:               &CDIHandler{cache: cache},
+			allocatable:       AllocatableDevices{"gpu-0-128": &AllocatableDevice{}},
+			checkpointManager: cm,
+			pluginPath:        t.TempDir(),
+			bootID:            "", // procfs unreadable
+		}
+		require.NoError(t, s.writeEpoch("")) // stored epoch also empty
+		checkpoint := newCheckpoint()
+		checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
+		require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+		require.NoError(t, s.reconcileCDISpecs())
+
+		after, err := os.ReadDir(cdiRoot)
+		require.NoError(t, err)
+		require.Empty(t, after, "an unreadable boot id must fail closed, not replay the checkpoint")
+	})
+}
+
+// A checkpoint holding one good and one bad claim must rebuild the good claim's spec
+// and quarantine the bad one, proving the reconcile loop is selective rather than
+// all-or-nothing (and not vacuously passing because nothing is ever written).
+func TestReconcileQuarantinesBadClaimButRebuildsGood(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128") // only the good device is allocatable
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["good"] = kfdDevices()
+	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil} // malformed -> quarantined
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Len(t, after, 1, "exactly the good claim's spec must be rebuilt")
+	data, err := os.ReadFile(filepath.Join(cdiRoot, after[0].Name()))
+	require.NoError(t, err)
+	require.Contains(t, string(data), "/dev/kfd")
+}
+
+// A CDI write error during replay is not self-healing: the kubelet may never re-Prepare
+// an already-prepared claim, so reconcile must fail startup loudly instead of
+// registering with a missing spec.
+func TestReconcileFailsLoudOnCDIWriteError(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	const claimUID = "claim-uid-1"
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	// Force WriteSpec to fail deterministically and independently of file permissions
+	// (which root ignores) by planting a directory where the spec file must be written.
+	specName := cdiapi.GenerateTransientSpecName(cdiVendor, cdiClass, claimUID)
+	require.NoError(t, os.Mkdir(filepath.Join(cdiRoot, specName+".yaml"), 0o755))
+
+	require.Error(t, s.reconcileCDISpecs(), "a CDI write failure during replay must fail startup, not be swallowed")
+}
+
+// A cross-boot discard must also delete any stale CDI spec files that survived on a
+// persistent spec directory, so the container runtime cannot resolve a claim against a
+// spec that now points at different hardware.
+func TestReconcileDiscardDeletesStaleSpecs(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	const claimUID = "claim-uid-1"
+	// A spec left on disk by a previous boot.
+	require.NoError(t, s.cdi.CreateClaimSpecFile(claimUID, kfdDevices()))
+	before, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.NotEmpty(t, before)
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.writeEpoch("boot-previous")) // force a cross-boot discard
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a cross-boot discard must delete the stale CDI spec, not leave it on disk")
 }

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -182,14 +182,16 @@ func testDeviceState(t *testing.T, cache *cdiapi.Cache, cm checkpointmanager.Che
 	return s
 }
 
-// kfdDevices is a well-formed single-device claim naming gpu-0-128 with a /dev/kfd node.
+// kfdDevices is a well-formed single-device claim naming gpu-0-128. Its node points at
+// /dev/null (a real char device, major 1 minor 3 on Linux) so the reconcile device-node
+// verification sees numbers that match the host in tests that expect a replay.
 func kfdDevices() PreparedDevices {
 	return PreparedDevices{
 		{
 			Device: drapbv1.Device{DeviceName: "gpu-0-128"},
 			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
 				DeviceNodes: []*cdispec.DeviceNode{
-					{Path: "/dev/kfd", HostPath: "/dev/kfd", Type: "c", Major: 1, Minor: 1, Permissions: "rw"},
+					{Path: "/dev/null", HostPath: "/dev/null", Type: "c", Major: 1, Minor: 3, Permissions: "rw"},
 				},
 			}},
 		},
@@ -249,7 +251,7 @@ func TestReconcileCDISpecs(t *testing.T) {
 
 	data, err := os.ReadFile(filepath.Join(cdiRoot, after[0].Name()))
 	require.NoError(t, err)
-	require.Contains(t, string(data), "/dev/kfd", "the rebuilt spec must carry the device node from the checkpoint")
+	require.Contains(t, string(data), "/dev/null", "the rebuilt spec must carry the device node from the checkpoint")
 }
 
 func TestValidatePreparedDevices(t *testing.T) {
@@ -483,7 +485,7 @@ func TestReconcileQuarantinesBadClaimButRebuildsGood(t *testing.T) {
 	require.Len(t, after, 1, "exactly the good claim's spec must be rebuilt")
 	data, err := os.ReadFile(filepath.Join(cdiRoot, after[0].Name()))
 	require.NoError(t, err)
-	require.Contains(t, string(data), "/dev/kfd")
+	require.Contains(t, string(data), "/dev/null")
 }
 
 // A CDI write error during replay is not self-healing: the kubelet may never re-Prepare
@@ -531,4 +533,61 @@ func TestReconcileDiscardDeletesStaleSpecs(t *testing.T) {
 	after, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
 	require.Empty(t, after, "a cross-boot discard must delete the stale CDI spec, not leave it on disk")
+}
+
+// A same-boot driver reload or repartition can renumber a device node without changing
+// the boot id. A checkpointed node whose major/minor no longer match the host is stale,
+// so reconcile discards it (and its specs) rather than replaying the wrong numbers.
+func TestReconcileDiscardsOnDeviceNodeRenumber(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128") // same boot: epoch matches, inventory has the device
+
+	// A node at /dev/null (major 1, minor 3) but recorded with the wrong major, as if the
+	// device was renumbered after the checkpoint was written.
+	stale := PreparedDevices{{
+		Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+		ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+			DeviceNodes: []*cdispec.DeviceNode{
+				{Path: "/dev/null", HostPath: "/dev/null", Type: "c", Major: 99, Minor: 3, Permissions: "rw"},
+			},
+		}},
+	}}
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = stale
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a checkpointed node whose device numbers moved must not be replayed")
+
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.Empty(t, reloaded.V1.PreparedClaims, "the stale checkpoint must be discarded")
+}
+
+// A checkpointed node whose HostPath no longer exists (device removed) is stale too, so
+// reconcile discards rather than replaying it.
+func TestReconcileDiscardsOnMissingDeviceNode(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	gone := PreparedDevices{{
+		Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+		ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+			DeviceNodes: []*cdispec.DeviceNode{
+				{Path: "/dev/does-not-exist-kfd", HostPath: "/dev/does-not-exist-kfd", Type: "c", Major: 1, Minor: 3, Permissions: "rw"},
+			},
+		}},
+	}}
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = gone
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a checkpointed node whose device path is gone must not be replayed")
 }

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -383,7 +383,7 @@ func TestReconcileDiscardsCheckpointFromDifferentBoot(t *testing.T) {
 }
 
 // A checkpointed device that is no longer in the allocatable inventory (removed or
-// skipped by discovery this boot) must be quarantined, not rebuilt from the checkpoint.
+// skipped by discovery this boot) must be skipped, not rebuilt from the checkpoint.
 func TestReconcileSkipsDeviceNotAllocatable(t *testing.T) {
 	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm) // gpu-0-128 is deliberately absent from allocatable
@@ -471,7 +471,7 @@ func TestReconcileRebuildsWithoutConfirmedRebootWhenNodesMatch(t *testing.T) {
 }
 
 // A checkpoint holding one good and one bad claim must rebuild the good claim's spec
-// and quarantine the bad one, proving the reconcile loop is selective rather than
+// and skip the bad one, proving the reconcile loop is selective rather than
 // all-or-nothing (and not vacuously passing because nothing is ever written).
 func TestReconcileQuarantinesBadClaimButRebuildsGood(t *testing.T) {
 	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
@@ -479,7 +479,7 @@ func TestReconcileQuarantinesBadClaimButRebuildsGood(t *testing.T) {
 
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["good"] = kfdDevices()
-	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil} // malformed -> quarantined
+	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil} // malformed -> skipped
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
 	require.NoError(t, s.reconcileCDISpecs())

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -175,31 +175,8 @@ func testDeviceState(t *testing.T, cache *cdiapi.Cache, cm checkpointmanager.Che
 		cdi:               &CDIHandler{cache: cache},
 		allocatable:       alloc,
 		checkpointManager: cm,
-		pluginPath:        t.TempDir(),
-		bootID:            "test-boot",
 	}
 	return s
-}
-
-// bindEpoch records an epoch for the checkpoint currently on disk, the way a real
-// checkpoint write does, so reconcile sees an epoch that describes it.
-func bindEpoch(t *testing.T, s *DeviceState) {
-	t.Helper()
-	cp := newCheckpoint()
-	require.NoError(t, s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, cp))
-	require.NoError(t, s.writeEpoch(cp.Checksum))
-}
-
-// bindEpochForBoot records an epoch describing the current checkpoint but under another
-// boot, which is the confirmed-reboot case.
-func bindEpochForBoot(t *testing.T, s *DeviceState, bootID string) {
-	t.Helper()
-	cp := newCheckpoint()
-	require.NoError(t, s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, cp))
-	saved := s.bootID
-	s.bootID = bootID
-	require.NoError(t, s.writeEpoch(cp.Checksum))
-	s.bootID = saved
 }
 
 // kfdDevices is a well-formed single-device claim naming gpu-0-128. Its node points at
@@ -258,7 +235,6 @@ func TestReconcileCDISpecs(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	before, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
@@ -326,7 +302,6 @@ func TestPrepareRepairsMissingCheckpointedSpec(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	before, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
@@ -351,7 +326,6 @@ func TestReconcileSkipsMalformedCheckpointEntry(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -372,7 +346,6 @@ func TestPrepareRejectsMalformedCheckpointEntry(t *testing.T) {
 		{Device: drapbv1.Device{DeviceName: ""}, ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}},
 	}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}}
 	_, err := s.Prepare(claim)
@@ -390,35 +363,12 @@ func TestReconcileRejectsHollowContainerEdits(t *testing.T) {
 		{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{}},
 	}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
 	after, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
 	require.Empty(t, after, "a hollow container-edits entry must not be written as a spec")
-}
-
-// A checkpoint written under a different boot must be discarded, not replayed: its
-// device nodes may now point at other hardware.
-func TestReconcileDiscardsCheckpointFromDifferentBoot(t *testing.T) {
-	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
-	s := testDeviceState(t, cache, cm, "gpu-0-128")
-
-	checkpoint := newCheckpoint()
-	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
-	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpochForBoot(t, s, "boot-previous") // same checkpoint, earlier boot
-
-	require.NoError(t, s.reconcileCDISpecs())
-
-	after, err := os.ReadDir(cdiRoot)
-	require.NoError(t, err)
-	require.Empty(t, after, "a checkpoint from a previous boot must not be replayed into a CDI spec")
-
-	reloaded := newCheckpoint()
-	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
-	require.Empty(t, reloaded.V1.PreparedClaims, "the stale checkpoint must be discarded")
 }
 
 // A checkpointed device that is no longer in the allocatable inventory (removed or
@@ -430,7 +380,6 @@ func TestReconcileSkipsDeviceNotAllocatable(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -450,7 +399,6 @@ func TestReconcileRejectsNestedNullDeviceNode(t *testing.T) {
 		{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{DeviceNodes: []*cdispec.DeviceNode{nil}}}},
 	}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs()) // must not panic
 
@@ -459,57 +407,25 @@ func TestReconcileRejectsNestedNullDeviceNode(t *testing.T) {
 	require.Empty(t, after, "a nested nil device node must be rejected, not written as a spec")
 }
 
-// The first restart after the boot-epoch field is introduced has no recorded epoch, and
-// a plugin-only upgrade keeps the same kubelet running. Because kubelet still holds the
-// claims, reconcile must NOT discard on a missing or unreadable epoch: deleting the specs
-// would strand claims kubelet will not re-Prepare. It rebuilds instead when the device
-// nodes still match, so the migration is seamless.
-func TestReconcileRebuildsWithoutConfirmedRebootWhenNodesMatch(t *testing.T) {
-	t.Run("epoch file missing", func(t *testing.T) {
-		cdiRoot, cache, cm := newCacheAndCheckpointer(t)
-		s := &DeviceState{
-			cdi:               &CDIHandler{cache: cache},
-			allocatable:       AllocatableDevices{"gpu-0-128": &AllocatableDevice{}},
-			checkpointManager: cm,
-			pluginPath:        t.TempDir(), // no boot-epoch file written -> stored == ""
-			bootID:            "test-boot",
-		}
-		checkpoint := newCheckpoint()
-		checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
-		require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-		bindEpoch(t, s)
+// Reconcile never removes checkpointed state. kubelet does not call Prepare again for a
+// claim it still considers prepared, so a rebuild is always safer than a discard.
+func TestReconcilePreservesTheCheckpointAndRebuilds(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
 
-		require.NoError(t, s.reconcileCDISpecs())
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-		after, err := os.ReadDir(cdiRoot)
-		require.NoError(t, err)
-		require.NotEmpty(t, after, "a missing epoch must rebuild, not discard, while kubelet still holds the claim")
+	require.NoError(t, s.reconcileCDISpecs())
 
-		reloaded := newCheckpoint()
-		require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
-		require.NotEmpty(t, reloaded.V1.PreparedClaims, "the checkpoint must be preserved, not discarded")
-	})
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.NotEmpty(t, after, "the spec must be rebuilt")
 
-	t.Run("boot id unreadable", func(t *testing.T) {
-		cdiRoot, cache, cm := newCacheAndCheckpointer(t)
-		s := &DeviceState{
-			cdi:               &CDIHandler{cache: cache},
-			allocatable:       AllocatableDevices{"gpu-0-128": &AllocatableDevice{}},
-			checkpointManager: cm,
-			pluginPath:        t.TempDir(),
-			bootID:            "", // procfs unreadable
-		}
-		checkpoint := newCheckpoint()
-		checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
-		require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-		bindEpoch(t, s)
-
-		require.NoError(t, s.reconcileCDISpecs())
-
-		after, err := os.ReadDir(cdiRoot)
-		require.NoError(t, err)
-		require.NotEmpty(t, after, "an unreadable boot id must rebuild, not discard, while kubelet still holds the claim")
-	})
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.Contains(t, reloaded.V1.PreparedClaims, "claim-uid-1", "the checkpoint must be preserved")
 }
 
 // A checkpoint holding one good and one bad claim must rebuild the good claim's spec
@@ -523,7 +439,6 @@ func TestReconcileQuarantinesBadClaimButRebuildsGood(t *testing.T) {
 	checkpoint.V1.PreparedClaims["good"] = kfdDevices()
 	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil} // malformed -> skipped
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.NoError(t, s.reconcileCDISpecs())
 
@@ -546,7 +461,6 @@ func TestReconcileFailsLoudOnCDIWriteError(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	// Force WriteSpec to fail deterministically and independently of file permissions
 	// (which root ignores) by planting a directory where the spec file must be written.
@@ -554,32 +468,6 @@ func TestReconcileFailsLoudOnCDIWriteError(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(cdiRoot, specName+".yaml"), 0o755))
 
 	require.Error(t, s.reconcileCDISpecs(), "a CDI write failure during replay must fail startup, not be swallowed")
-}
-
-// A cross-boot discard must also delete any stale CDI spec files that survived on a
-// persistent spec directory, so the container runtime cannot resolve a claim against a
-// spec that now points at different hardware.
-func TestReconcileDiscardDeletesStaleSpecs(t *testing.T) {
-	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
-	s := testDeviceState(t, cache, cm, "gpu-0-128")
-
-	const claimUID = "claim-uid-1"
-	// A spec left on disk by a previous boot.
-	require.NoError(t, s.cdi.CreateClaimSpecFile(claimUID, kfdDevices()))
-	before, err := os.ReadDir(cdiRoot)
-	require.NoError(t, err)
-	require.NotEmpty(t, before)
-
-	checkpoint := newCheckpoint()
-	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
-	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpochForBoot(t, s, "boot-previous") // force a cross-boot discard
-
-	require.NoError(t, s.reconcileCDISpecs())
-
-	after, err := os.ReadDir(cdiRoot)
-	require.NoError(t, err)
-	require.Empty(t, after, "a cross-boot discard must delete the stale CDI spec, not leave it on disk")
 }
 
 // A same-boot driver reload or repartition can renumber a device node without changing
@@ -604,7 +492,6 @@ func TestReconcileFailsStartupOnDeviceNodeRenumber(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = stale
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.Error(t, s.reconcileCDISpecs(), "a same-boot renumber must fail startup, not discard")
 
@@ -634,7 +521,6 @@ func TestReconcileFailsStartupOnMissingDeviceNode(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = gone
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.Error(t, s.reconcileCDISpecs(), "a missing node without a confirmed reboot must fail startup")
 
@@ -647,34 +533,6 @@ func TestReconcileFailsStartupOnMissingDeviceNode(t *testing.T) {
 	require.NotEmpty(t, reloaded.V1.PreparedClaims, "startup must fail without discarding the checkpoint")
 }
 
-// A reboot only authorizes a discard when nothing wrote the checkpoint after the epoch
-// was recorded. If an older binary prepared claims in between, the epoch describes a
-// different checkpoint, and discarding would drop claims kubelet may now hold.
-func TestReconcileKeepsCheckpointWrittenAfterTheEpoch(t *testing.T) {
-	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
-	s := testDeviceState(t, cache, cm, "gpu-0-128")
-
-	// Epoch recorded under an earlier boot, for an empty checkpoint.
-	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, newCheckpoint()))
-	bindEpochForBoot(t, s, "boot-previous")
-
-	// Another binary then prepares a claim, so the checkpoint no longer matches.
-	checkpoint := newCheckpoint()
-	checkpoint.V1.PreparedClaims["claim-uid-1"] = kfdDevices()
-	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-
-	require.NoError(t, s.reconcileCDISpecs())
-
-	reloaded := newCheckpoint()
-	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
-	require.Contains(t, reloaded.V1.PreparedClaims, "claim-uid-1",
-		"a claim prepared after the epoch was recorded must not be discarded on a boot change")
-
-	after, err := os.ReadDir(cdiRoot)
-	require.NoError(t, err)
-	require.NotEmpty(t, after, "its CDI spec must be rebuilt rather than deleted")
-}
-
 // Unprepare is reached again on every teardown, so a malformed checkpoint entry must be
 // rejected there rather than dereferenced.
 func TestUnprepareRejectsMalformedEntryWithoutPanic(t *testing.T) {
@@ -684,7 +542,6 @@ func TestUnprepareRejectsMalformedEntryWithoutPanic(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil}
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	var err error
 	require.NotPanics(t, func() { err = s.Unprepare("bad") })
@@ -700,11 +557,32 @@ func TestUnprepareRejectsDeviceMissingFromInventory(t *testing.T) {
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["c"] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
-	bindEpoch(t, s)
 
 	require.Error(t, s.Unprepare("c"))
 
 	reloaded := newCheckpoint()
 	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
 	require.Contains(t, reloaded.V1.PreparedClaims, "c", "a failed unprepare must not drop the claim")
+}
+
+// CDI allows a device node to carry only a path, letting the runtime resolve the numbers,
+// and the VFIO path emits exactly that. Such a node must still be verified rather than
+// skipped, or a checkpoint naming a group that no longer exists would be replayed.
+func TestReconcileVerifiesPathOnlyDeviceNodes(t *testing.T) {
+	_, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-vfio-0")
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["c"] = PreparedDevices{
+		{
+			Device: drapbv1.Device{DeviceName: "gpu-vfio-0"},
+			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+				// No HostPath and no numbers, as the VFIO fallback produces.
+				DeviceNodes: []*cdispec.DeviceNode{{Path: "/dev/vfio/no-such-group"}},
+			}},
+		},
+	}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.Error(t, s.reconcileCDISpecs(), "a path-only node that no longer resolves must fail startup")
 }

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -33,13 +33,23 @@ limitations under the License.
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ROCm/k8s-gpu-dra-driver/pkg/consts"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+
+	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
+	cdispec "tags.cncf.io/container-device-interface/specs-go"
 )
 
 func TestRestoreFromVfio(t *testing.T) {
@@ -172,4 +182,162 @@ func TestPreparedDevicesGetDevices(t *testing.T) {
 			assert.Equal(t, test.expected, devices)
 		})
 	}
+}
+
+func TestReconcileCDISpecs(t *testing.T) {
+	cdiRoot := t.TempDir()
+	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
+	assert.NoError(t, err)
+	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
+	assert.NoError(t, err)
+
+	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["claim-uid-1"] = PreparedDevices{
+		{
+			Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+				DeviceNodes: []*cdispec.DeviceNode{
+					{Path: "/dev/kfd", HostPath: "/dev/kfd", Type: "c", Major: 1, Minor: 1, Permissions: "rw"},
+				},
+			}},
+		},
+	}
+	assert.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	// The spec dir starts empty, as a reboot leaves it.
+	before, err := os.ReadDir(cdiRoot)
+	assert.NoError(t, err)
+	assert.Empty(t, before)
+
+	assert.NoError(t, s.reconcileCDISpecs())
+
+	after, err := os.ReadDir(cdiRoot)
+	assert.NoError(t, err)
+	require.NotEmpty(t, after, "reconcile should rebuild the CDI spec from the checkpoint")
+
+	data, err := os.ReadFile(filepath.Join(cdiRoot, after[0].Name()))
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "/dev/kfd", "the rebuilt spec must carry the device node from the checkpoint")
+}
+
+func TestValidatePreparedDevices(t *testing.T) {
+	edits := &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}
+	valid := PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: edits}}
+	require.NoError(t, validatePreparedDevices("uid", valid))
+
+	bad := map[string]PreparedDevices{
+		"empty":               {},
+		"nil device":          {nil},
+		"no device name":      {{Device: drapbv1.Device{}, ContainerEdits: edits}},
+		"nil container edits": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}}},
+	}
+	for name, pds := range bad {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, validatePreparedDevices("uid", pds))
+		})
+	}
+}
+
+// A checkpoint-hit Prepare must recreate a spec that a tmpfs-clearing restart
+// removed, rather than reporting the claim as prepared with no spec on disk.
+func TestPrepareRepairsMissingCheckpointedSpec(t *testing.T) {
+	cdiRoot := t.TempDir()
+	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
+	require.NoError(t, err)
+	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
+	require.NoError(t, err)
+
+	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+
+	const claimUID = "claim-uid-1"
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims[claimUID] = PreparedDevices{
+		{
+			Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+				DeviceNodes: []*cdispec.DeviceNode{
+					{Path: "/dev/kfd", HostPath: "/dev/kfd", Type: "c", Major: 1, Minor: 1, Permissions: "rw"},
+				},
+			}},
+		},
+	}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	before, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, before)
+
+	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}}
+	devices, err := s.Prepare(claim)
+	require.NoError(t, err)
+	require.Len(t, devices, 1)
+
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.NotEmpty(t, after, "a checkpoint-hit Prepare must recreate the missing CDI spec")
+}
+
+// A malformed checkpoint entry is logged and skipped at startup, not a panic.
+func TestReconcileSkipsMalformedCheckpointEntry(t *testing.T) {
+	cdiRoot := t.TempDir()
+	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
+	require.NoError(t, err)
+	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
+	require.NoError(t, err)
+
+	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	require.NoError(t, s.reconcileCDISpecs())
+}
+
+// A checkpoint-hit Prepare must fail closed on a malformed entry rather than
+// report the claim as prepared. A device with no name cannot become a CDI spec,
+// so Prepare has to return an error instead of the devices.
+func TestPrepareRejectsMalformedCheckpointEntry(t *testing.T) {
+	cdiRoot := t.TempDir()
+	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
+	require.NoError(t, err)
+	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
+	require.NoError(t, err)
+
+	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+
+	const claimUID = "claim-uid-1"
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims[claimUID] = PreparedDevices{
+		{Device: drapbv1.Device{DeviceName: ""}, ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}},
+	}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}}
+	_, err = s.Prepare(claim)
+	require.Error(t, err, "checkpoint-hit Prepare with a malformed entry must fail closed, not report success")
+}
+
+// A checkpoint entry whose container edits wrapper is present but hollow (nil
+// inner edits) must be rejected during reconciliation, not dereferenced into a
+// panic while rebuilding the CDI spec.
+func TestReconcileRejectsHollowContainerEdits(t *testing.T) {
+	cdiRoot := t.TempDir()
+	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(cdiRoot))
+	require.NoError(t, err)
+	cm, err := checkpointmanager.NewCheckpointManager(t.TempDir())
+	require.NoError(t, err)
+
+	s := &DeviceState{cdi: &CDIHandler{cache: cache}, checkpointManager: cm}
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["hollow"] = PreparedDevices{
+		{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{}},
+	}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+
+	// Must not panic; the malformed entry is logged and skipped.
+	require.NoError(t, s.reconcileCDISpecs())
 }

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -418,10 +418,12 @@ func TestReconcileRejectsNestedNullDeviceNode(t *testing.T) {
 	require.Empty(t, after, "a nested nil device node must be rejected, not written as a spec")
 }
 
-// The boot epoch guard must fail closed, not open. A missing epoch file or an
-// unreadable boot id has to discard the checkpoint rather than replay it: guarding
-// only on inequality (stored != bootID) would replay when both are empty.
-func TestReconcileFailsClosedWithoutBootEpoch(t *testing.T) {
+// The first restart after the boot-epoch field is introduced has no recorded epoch, and
+// a plugin-only upgrade keeps the same kubelet running. Because kubelet still holds the
+// claims, reconcile must NOT discard on a missing or unreadable epoch: deleting the specs
+// would strand claims kubelet will not re-Prepare. It rebuilds instead when the device
+// nodes still match, so the migration is seamless.
+func TestReconcileRebuildsWithoutConfirmedRebootWhenNodesMatch(t *testing.T) {
 	t.Run("epoch file missing", func(t *testing.T) {
 		cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 		s := &DeviceState{
@@ -439,11 +441,13 @@ func TestReconcileFailsClosedWithoutBootEpoch(t *testing.T) {
 
 		after, err := os.ReadDir(cdiRoot)
 		require.NoError(t, err)
-		require.Empty(t, after, "a checkpoint with no recorded boot epoch must not be replayed")
+		require.NotEmpty(t, after, "a missing epoch must rebuild, not discard, while kubelet still holds the claim")
+
+		reloaded := newCheckpoint()
+		require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+		require.NotEmpty(t, reloaded.V1.PreparedClaims, "the checkpoint must be preserved, not discarded")
 	})
 
-	// Both the stored epoch and the current boot id are empty. The old inequality-only
-	// guard would see "" == "" and replay; the fail-closed guard must discard.
 	t.Run("boot id unreadable", func(t *testing.T) {
 		cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 		s := &DeviceState{
@@ -462,7 +466,7 @@ func TestReconcileFailsClosedWithoutBootEpoch(t *testing.T) {
 
 		after, err := os.ReadDir(cdiRoot)
 		require.NoError(t, err)
-		require.Empty(t, after, "an unreadable boot id must fail closed, not replay the checkpoint")
+		require.NotEmpty(t, after, "an unreadable boot id must rebuild, not discard, while kubelet still holds the claim")
 	})
 }
 
@@ -538,7 +542,9 @@ func TestReconcileDiscardDeletesStaleSpecs(t *testing.T) {
 // A same-boot driver reload or repartition can renumber a device node without changing
 // the boot id. A checkpointed node whose major/minor no longer match the host is stale,
 // so reconcile discards it (and its specs) rather than replaying the wrong numbers.
-func TestReconcileDiscardsOnDeviceNodeRenumber(t *testing.T) {
+// Same boot (epoch matches), so a renumbered node is not a reboot. kubelet still holds the
+// claim, so reconcile must fail startup rather than discard the spec it relies on.
+func TestReconcileFailsStartupOnDeviceNodeRenumber(t *testing.T) {
 	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm, "gpu-0-128") // same boot: epoch matches, inventory has the device
 
@@ -556,7 +562,7 @@ func TestReconcileDiscardsOnDeviceNodeRenumber(t *testing.T) {
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = stale
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	require.NoError(t, s.reconcileCDISpecs())
+	require.Error(t, s.reconcileCDISpecs(), "a same-boot renumber must fail startup, not discard")
 
 	after, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
@@ -564,12 +570,12 @@ func TestReconcileDiscardsOnDeviceNodeRenumber(t *testing.T) {
 
 	reloaded := newCheckpoint()
 	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
-	require.Empty(t, reloaded.V1.PreparedClaims, "the stale checkpoint must be discarded")
+	require.NotEmpty(t, reloaded.V1.PreparedClaims, "startup must fail without discarding the checkpoint kubelet still relies on")
 }
 
-// A checkpointed node whose HostPath no longer exists (device removed) is stale too, so
-// reconcile discards rather than replaying it.
-func TestReconcileDiscardsOnMissingDeviceNode(t *testing.T) {
+// A checkpointed node whose HostPath no longer exists (device removed) is stale too, and
+// without a confirmed reboot reconcile must fail startup rather than discard it.
+func TestReconcileFailsStartupOnMissingDeviceNode(t *testing.T) {
 	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm, "gpu-0-128")
 
@@ -585,9 +591,13 @@ func TestReconcileDiscardsOnMissingDeviceNode(t *testing.T) {
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = gone
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	require.NoError(t, s.reconcileCDISpecs())
+	require.Error(t, s.reconcileCDISpecs(), "a missing node without a confirmed reboot must fail startup")
 
 	after, err := os.ReadDir(cdiRoot)
 	require.NoError(t, err)
 	require.Empty(t, after, "a checkpointed node whose device path is gone must not be replayed")
+
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.NotEmpty(t, reloaded.V1.PreparedClaims, "startup must fail without discarding the checkpoint")
 }

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -33,6 +33,8 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
@@ -163,8 +166,8 @@ func newCacheAndCheckpointer(t *testing.T) (string, *cdiapi.Cache, checkpointman
 	return cdiRoot, cache, cm
 }
 
-// testDeviceState wires a DeviceState with a temp plugin dir, a matching boot epoch,
-// and the named allocatable devices, so reconcile replays instead of discarding.
+// testDeviceState wires a DeviceState over a temp CDI cache and checkpoint dir with the
+// named devices allocatable.
 func testDeviceState(t *testing.T, cache *cdiapi.Cache, cm checkpointmanager.CheckpointManager, devices ...string) *DeviceState {
 	t.Helper()
 	alloc := AllocatableDevices{}
@@ -179,18 +182,23 @@ func testDeviceState(t *testing.T, cache *cdiapi.Cache, cm checkpointmanager.Che
 	return s
 }
 
-// kfdDevices is a well-formed single-device claim naming gpu-0-128. Its node points at
-// /dev/null (a real char device, major 1 minor 3 on Linux) so the reconcile device-node
-// verification sees numbers that match the host in tests that expect a replay.
+// devNull is /dev/null as the host sees it, so a checkpointed node built from it passes the
+// device-node check without hardcoding the numbers.
+func devNull() cdispec.DeviceNode {
+	major, minor, devType, _, err := getDeviceAttrs("/dev/null")
+	if err != nil {
+		panic(err)
+	}
+	return cdispec.DeviceNode{Path: "/dev/null", HostPath: "/dev/null", Type: devType, Major: major, Minor: minor, Permissions: "rw"}
+}
+
+// kfdDevices is a well-formed single-device claim naming gpu-0-128 whose node is /dev/null.
 func kfdDevices() PreparedDevices {
+	node := devNull()
 	return PreparedDevices{
 		{
-			Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
-				DeviceNodes: []*cdispec.DeviceNode{
-					{Path: "/dev/null", HostPath: "/dev/null", Type: "c", Major: 1, Minor: 3, Permissions: "rw"},
-				},
-			}},
+			Device:         drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{DeviceNodes: []*cdispec.DeviceNode{&node}}},
 		},
 	}
 }
@@ -268,26 +276,29 @@ func TestValidatePreparedDevices(t *testing.T) {
 
 	// Each bad case keeps an otherwise usable edit set, so it fails on its own defect
 	// rather than on a shared missing field.
-	bad := map[string]PreparedDevices{
-		"empty":               {},
-		"nil device":          {nil},
-		"no device name":      {{Device: drapbv1.Device{}, ContainerEdits: editsWith(nil)}},
-		"nil container edits": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}}},
-		"hollow edits":        {{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{}}},
-		"no device nodes": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}}},
-		"nil deviceNode": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.DeviceNodes = append(e.DeviceNodes, nil) })}},
-		"nil hook": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.Hooks = []*cdispec.Hook{nil} })}},
-		"nil mount": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.Mounts = []*cdispec.Mount{nil} })}},
-		"nil netDevice": {{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.NetDevices = []*cdispec.LinuxNetDevice{nil} })}},
+	bad := map[string]struct {
+		pds  PreparedDevices
+		want string
+	}{
+		"empty":               {PreparedDevices{}, "no prepared devices"},
+		"nil device":          {PreparedDevices{nil}, "nil prepared device"},
+		"no device name":      {PreparedDevices{{Device: drapbv1.Device{}, ContainerEdits: editsWith(nil)}}, "no name"},
+		"nil container edits": {PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"}}}, "no container edits"},
+		"hollow edits":        {PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"}, ContainerEdits: &cdiapi.ContainerEdits{}}}, "no container edits"},
+		"no device nodes": {PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}}}, "grants no device nodes"},
+		"nil deviceNode": {PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.DeviceNodes = append(e.DeviceNodes, nil) })}}, "nil deviceNodes[1]"},
+		"nil hook": {PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.Hooks = []*cdispec.Hook{nil} })}}, "nil hooks[0]"},
+		"nil mount": {PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.Mounts = []*cdispec.Mount{nil} })}}, "nil mounts[0]"},
+		"nil netDevice": {PreparedDevices{{Device: drapbv1.Device{DeviceName: "gpu-0-128"},
+			ContainerEdits: editsWith(func(e *cdispec.ContainerEdits) { e.NetDevices = []*cdispec.LinuxNetDevice{nil} })}}, "nil netDevices[0]"},
 	}
-	for name, pds := range bad {
+	for name, tc := range bad {
 		t.Run(name, func(t *testing.T) {
-			require.Error(t, validatePreparedDevices("uid", pds))
+			require.ErrorContains(t, validatePreparedDevices("uid", tc.pds), tc.want)
 		})
 	}
 }
@@ -349,7 +360,7 @@ func TestPrepareRejectsMalformedCheckpointEntry(t *testing.T) {
 
 	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}}
 	_, err := s.Prepare(claim)
-	require.Error(t, err, "checkpoint-hit Prepare with a malformed entry must fail closed, not report success")
+	require.ErrorContains(t, err, "cannot be prepared from its checkpoint entry")
 }
 
 // A non-nil but hollow ContainerEdits (nil inner edits) must be rejected during
@@ -431,8 +442,8 @@ func TestReconcileRejectsNestedNullDeviceNode(t *testing.T) {
 	require.Empty(t, after, "a nested nil device node must be rejected, not written as a spec")
 }
 
-// Reconcile never removes checkpointed state. kubelet does not call Prepare again for a
-// claim it still considers prepared, so a rebuild is always safer than a discard.
+// Reconcile never removes checkpointed state: a running kubelet does not Prepare a claim
+// again, so the entry is all a later Unprepare has to go on.
 func TestReconcilePreservesTheCheckpointAndRebuilds(t *testing.T) {
 	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm, "gpu-0-128")
@@ -494,72 +505,71 @@ func TestReconcileFailsLoudOnCDIWriteError(t *testing.T) {
 	require.Error(t, s.reconcileCDISpecs(), "a CDI write failure during replay must fail startup, not be swallowed")
 }
 
-// A same-boot driver reload or repartition can renumber a device node without changing
-// the boot id. A checkpointed node whose major/minor no longer match the host is stale,
-// so reconcile discards it (and its specs) rather than replaying the wrong numbers.
-// Same boot (epoch matches), so a renumbered node is not a reboot. kubelet still holds the
-// claim, so reconcile must fail startup rather than discard the spec it relies on.
-func TestReconcileFailsStartupOnDeviceNodeRenumber(t *testing.T) {
-	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
-	s := testDeviceState(t, cache, cm, "gpu-0-128") // same boot: epoch matches, inventory has the device
-
-	// A node at /dev/null (major 1, minor 3) but recorded with the wrong major, as if the
-	// device was renumbered after the checkpoint was written.
-	stale := PreparedDevices{{
-		Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-		ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
-			DeviceNodes: []*cdispec.DeviceNode{
-				{Path: "/dev/null", HostPath: "/dev/null", Type: "c", Major: 99, Minor: 3, Permissions: "rw"},
-			},
-		}},
+// staleClaim is a well-formed single-device claim whose only device node is the given
+// one, for entries that no longer match the host.
+func staleClaim(node cdispec.DeviceNode) PreparedDevices {
+	return PreparedDevices{{
+		Device:         drapbv1.Device{DeviceName: "gpu-0-128"},
+		ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{DeviceNodes: []*cdispec.DeviceNode{&node}}},
 	}}
+}
+
+// requireQuarantined checks that reconcile removed the stale claim's spec, kept its
+// checkpoint entry, and that a checkpoint-hit Prepare for it fails instead of replaying.
+func requireQuarantined(t *testing.T, s *DeviceState, cm checkpointmanager.CheckpointManager, cdiRoot, claimUID string) {
+	t.Helper()
+	after, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Empty(t, after, "a stale entry must lose its spec, not be replayed")
+
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.Contains(t, reloaded.V1.PreparedClaims, claimUID, "the entry must stay for a later Unprepare")
+
+	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}}
+	_, err = s.Prepare(claim)
+	require.ErrorContains(t, err, "recreate the pod")
+}
+
+// A driver reload or repartition can renumber a device node within a boot, and a reboot
+// can renumber all of them. A node recorded with numbers that no longer match the host
+// is quarantined: its spec goes, its entry stays, and startup carries on for the rest.
+func TestReconcileQuarantinesRenumberedDeviceNode(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	node := devNull()
+	node.Major++ // recorded with the wrong major
+	stale := staleClaim(node)
+	require.NoError(t, s.cdi.CreateClaimSpecFile("claim-uid-1", stale))
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = stale
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	require.Error(t, s.reconcileCDISpecs(), "a same-boot renumber must fail startup, not discard")
-
-	after, err := os.ReadDir(cdiRoot)
-	require.NoError(t, err)
-	require.Empty(t, after, "a checkpointed node whose device numbers moved must not be replayed")
-
-	reloaded := newCheckpoint()
-	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
-	require.NotEmpty(t, reloaded.V1.PreparedClaims, "startup must fail without discarding the checkpoint kubelet still relies on")
+	require.NoError(t, s.reconcileCDISpecs(), "one stale claim must not take the plugin down")
+	requireQuarantined(t, s, cm, cdiRoot, "claim-uid-1")
 }
 
-// A checkpointed node whose HostPath no longer exists (device removed) is stale too, and
-// without a confirmed reboot reconcile must fail startup rather than discard it.
-func TestReconcileFailsStartupOnMissingDeviceNode(t *testing.T) {
+// A node whose path is gone (device removed) is quarantined the same way.
+func TestReconcileQuarantinesMissingDeviceNode(t *testing.T) {
 	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm, "gpu-0-128")
 
-	gone := PreparedDevices{{
-		Device: drapbv1.Device{DeviceName: "gpu-0-128"},
-		ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
-			DeviceNodes: []*cdispec.DeviceNode{
-				{Path: "/dev/does-not-exist-kfd", HostPath: "/dev/does-not-exist-kfd", Type: "c", Major: 1, Minor: 3, Permissions: "rw"},
-			},
-		}},
-	}}
+	node := devNull()
+	node.Path, node.HostPath = "/dev/does-not-exist-kfd", "/dev/does-not-exist-kfd"
+	gone := staleClaim(node)
+	require.NoError(t, s.cdi.CreateClaimSpecFile("claim-uid-1", gone))
 	checkpoint := newCheckpoint()
 	checkpoint.V1.PreparedClaims["claim-uid-1"] = gone
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	require.Error(t, s.reconcileCDISpecs(), "a missing node without a confirmed reboot must fail startup")
-
-	after, err := os.ReadDir(cdiRoot)
-	require.NoError(t, err)
-	require.Empty(t, after, "a checkpointed node whose device path is gone must not be replayed")
-
-	reloaded := newCheckpoint()
-	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
-	require.NotEmpty(t, reloaded.V1.PreparedClaims, "startup must fail without discarding the checkpoint")
+	require.NoError(t, s.reconcileCDISpecs())
+	requireQuarantined(t, s, cm, cdiRoot, "claim-uid-1")
 }
 
-// Unprepare is reached again on every teardown, so a malformed checkpoint entry must be
-// rejected there rather than dereferenced.
-func TestUnprepareRejectsMalformedEntryWithoutPanic(t *testing.T) {
+// Unprepare is reached on every teardown, so a malformed entry must be dropped there
+// rather than dereferenced or left to wedge the pod's deletion.
+func TestUnprepareDropsMalformedEntryWithoutPanic(t *testing.T) {
 	_, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm)
 
@@ -569,12 +579,17 @@ func TestUnprepareRejectsMalformedEntryWithoutPanic(t *testing.T) {
 
 	var err error
 	require.NotPanics(t, func() { err = s.Unprepare("bad") })
-	require.Error(t, err, "a malformed entry must fail unprepare, not be dereferenced")
+	require.NoError(t, err, "a malformed entry must not block teardown")
+
+	reloaded := newCheckpoint()
+	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
+	require.NotContains(t, reloaded.V1.PreparedClaims, "bad")
 }
 
-// Reporting success for a device that is no longer in the inventory would tell kubelet
-// the host state was restored when it cannot have been.
-func TestUnprepareRejectsDeviceMissingFromInventory(t *testing.T) {
+// A device that left the inventory (removed, or renamed by an on-demand VFIO conversion
+// before a restart) has nothing to restore against; the claim is still released so the
+// pod can be deleted, and the host state is left to #94.
+func TestUnprepareReleasesDeviceMissingFromInventory(t *testing.T) {
 	_, cache, cm := newCacheAndCheckpointer(t)
 	s := testDeviceState(t, cache, cm) // nothing allocatable
 
@@ -582,31 +597,194 @@ func TestUnprepareRejectsDeviceMissingFromInventory(t *testing.T) {
 	checkpoint.V1.PreparedClaims["c"] = kfdDevices()
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	require.Error(t, s.Unprepare("c"))
+	require.NoError(t, s.Unprepare("c"))
 
 	reloaded := newCheckpoint()
 	require.NoError(t, cm.GetCheckpoint(DriverPluginCheckpointFile, reloaded))
-	require.Contains(t, reloaded.V1.PreparedClaims, "c", "a failed unprepare must not drop the claim")
+	require.NotContains(t, reloaded.V1.PreparedClaims, "c", "the claim must be released")
 }
 
-// CDI allows a device node to carry only a path, letting the runtime resolve the numbers,
-// and the VFIO path emits exactly that. Such a node must still be verified rather than
-// skipped, or a checkpoint naming a group that no longer exists would be replayed.
+// CDI allows a device node to carry only a path, and the VFIO path emits exactly that.
+// Such a node is verified by path rather than skipped, so a group that no longer exists
+// is quarantined like any other stale node.
 func TestReconcileVerifiesPathOnlyDeviceNodes(t *testing.T) {
-	_, cache, cm := newCacheAndCheckpointer(t)
-	s := testDeviceState(t, cache, cm, "gpu-vfio-0")
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
 
+	stale := staleClaim(cdispec.DeviceNode{Path: "/dev/vfio/no-such-group"})
+	require.NoError(t, s.cdi.CreateClaimSpecFile("c", stale))
 	checkpoint := newCheckpoint()
-	checkpoint.V1.PreparedClaims["c"] = PreparedDevices{
-		{
-			Device: drapbv1.Device{DeviceName: "gpu-vfio-0"},
-			ContainerEdits: &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
-				// No HostPath and no numbers, as the VFIO fallback produces.
-				DeviceNodes: []*cdispec.DeviceNode{{Path: "/dev/vfio/no-such-group"}},
-			}},
-		},
-	}
+	checkpoint.V1.PreparedClaims["c"] = stale
 	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
 
-	require.Error(t, s.reconcileCDISpecs(), "a path-only node that no longer resolves must fail startup")
+	require.NoError(t, s.reconcileCDISpecs())
+	requireQuarantined(t, s, cm, cdiRoot, "c")
+}
+
+func TestDeviceNodesCurrent(t *testing.T) {
+	current := devNull()
+	renumbered := devNull()
+	renumbered.Minor++
+	retyped := devNull()
+	retyped.Type = "b"
+	gone := devNull()
+	gone.Path, gone.HostPath = "/dev/does-not-exist", "/dev/does-not-exist"
+
+	tests := map[string]struct {
+		node cdispec.DeviceNode
+		want string // empty means current
+	}{
+		"matches the host":            {node: current},
+		"path only, resolves":         {node: cdispec.DeviceNode{Path: "/dev/null"}},
+		"path only, gone":             {node: cdispec.DeviceNode{Path: "/dev/does-not-exist"}, want: "no longer resolves"},
+		"no path at all":              {node: cdispec.DeviceNode{Type: "c", Major: 1, Minor: 3}},
+		"numbers moved":               {node: renumbered, want: "recorded"},
+		"type changed":                {node: retyped, want: "is type"},
+		"host path gone":              {node: gone, want: "no longer resolves"},
+		"host path wins over path":    {node: cdispec.DeviceNode{Path: "/dev/does-not-exist", HostPath: "/dev/null"}},
+		"numbers unrecorded, resolve": {node: cdispec.DeviceNode{Path: "/dev/null", HostPath: "/dev/null", Type: current.Type}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := deviceNodesCurrent(staleClaim(tc.node))
+			if tc.want == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+// writeRawCheckpoint stores a hand-built checkpoint file whose checksum matches what the
+// decoded struct re-marshals to, as VerifyChecksum computes it.
+func writeRawCheckpoint(t *testing.T, dir, canonical, stored string) {
+	t.Helper()
+	sum := checksum.New([]byte(canonical))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, DriverPluginCheckpointFile), fmt.Appendf(nil, stored, sum), 0o600))
+}
+
+// A checkpoint whose v1 payload or preparedClaims map is an explicit null decodes to nil.
+// newCheckpoint pre-populates both, so only a file that spells the null out reaches these.
+func TestLoadCheckpointHandlesExplicitNulls(t *testing.T) {
+	t.Run("v1 null is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		cm, err := checkpointmanager.NewCheckpointManager(dir)
+		require.NoError(t, err)
+		writeRawCheckpoint(t, dir, `{"checksum":0}`, `{"checksum":%d,"v1":null}`)
+
+		s := &DeviceState{checkpointManager: cm}
+		_, err = s.loadCheckpoint()
+		require.ErrorContains(t, err, "no v1 payload")
+
+		_, err = s.Prepare(&resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: "c"}})
+		require.ErrorContains(t, err, "no v1 payload")
+		require.ErrorContains(t, s.Unprepare("c"), "no v1 payload")
+		require.ErrorContains(t, s.reconcileCDISpecs(), "no v1 payload")
+	})
+
+	t.Run("preparedClaims null becomes an empty map", func(t *testing.T) {
+		dir := t.TempDir()
+		cm, err := checkpointmanager.NewCheckpointManager(dir)
+		require.NoError(t, err)
+		writeRawCheckpoint(t, dir, `{"checksum":0,"v1":{}}`, `{"checksum":%d,"v1":{"preparedClaims":null}}`)
+
+		s := &DeviceState{checkpointManager: cm}
+		checkpoint, err := s.loadCheckpoint()
+		require.NoError(t, err)
+		require.NotNil(t, checkpoint.V1.PreparedClaims)
+		require.NotPanics(t, func() { checkpoint.V1.PreparedClaims["c"] = kfdDevices() })
+		require.NoError(t, s.Unprepare("c"), "an unknown claim on a null map is a no-op")
+	})
+}
+
+// FuzzCheckpointEntry decodes arbitrary JSON as a checkpoint entry and drives it through the
+// validation and, when that passes, the CDI spec writer. Neither may panic.
+func FuzzCheckpointEntry(f *testing.F) {
+	seed, err := json.Marshal(kfdDevices())
+	require.NoError(f, err)
+	f.Add(seed)
+	f.Add([]byte(`null`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`[null]`))
+	f.Add([]byte(`[{"deviceName":"gpu-0-128"}]`))
+	f.Add([]byte(`[{"deviceName":"gpu-0-128","ContainerEdits":{}}]`))
+	f.Add([]byte(`[{"deviceName":"gpu-0-128","ContainerEdits":{"deviceNodes":[null]}}]`))
+	f.Add([]byte(`[{"deviceName":"gpu-0-128","ContainerEdits":{"deviceNodes":[{"path":"/dev/null"}],"hooks":[null]}}]`))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var pds PreparedDevices
+		if err := json.Unmarshal(data, &pds); err != nil {
+			return
+		}
+		if err := validatePreparedDevices("claim-uid-1", pds); err != nil {
+			return
+		}
+		cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(t.TempDir()))
+		require.NoError(t, err)
+		h := &CDIHandler{cache: cache}
+		// A validated entry may still be rejected by CDI's own validation; it must not panic.
+		_ = h.CreateClaimSpecFile("claim-uid-1", pds)
+		_ = deviceNodesCurrent(pds)
+	})
+}
+
+// A checkpoint-hit Prepare that cannot write the spec must fail rather than report the
+// claim as prepared with nothing on disk, the same as the startup rebuild.
+func TestPrepareFailsWhenTheSpecCannotBeWritten(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	const claimUID = "claim-uid-1"
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	specName := cdiapi.GenerateTransientSpecName(cdiVendor, cdiClass, claimUID)
+	require.NoError(t, os.Mkdir(filepath.Join(cdiRoot, specName+".yaml"), 0o755))
+
+	_, err := s.Prepare(&resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}})
+	require.ErrorContains(t, err, "unable to ensure the CDI spec")
+}
+
+// The common spec is part of the response too, so a checkpoint hit that cannot write it fails.
+func TestPrepareFailsWhenTheCommonSpecCannotBeWritten(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm, "gpu-0-128")
+
+	const claimUID = "claim-uid-1"
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims[claimUID] = kfdDevices()
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	specName := cdiapi.GenerateTransientSpecName(cdiVendor, cdiClass, cdiCommonDeviceName)
+	require.NoError(t, os.Mkdir(filepath.Join(cdiRoot, specName+".yaml"), 0o755))
+
+	_, err := s.Prepare(&resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: types.UID(claimUID)}})
+	require.ErrorContains(t, err, "unable to ensure the common CDI spec")
+}
+
+// Removing a quarantined claim's spec can fail too; that is not swallowed either.
+func TestReconcileFailsWhenAStaleSpecCannotBeRemoved(t *testing.T) {
+	cdiRoot, cache, cm := newCacheAndCheckpointer(t)
+	s := testDeviceState(t, cache, cm)
+
+	checkpoint := newCheckpoint()
+	checkpoint.V1.PreparedClaims["bad"] = PreparedDevices{nil}
+	require.NoError(t, cm.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint))
+	// A non-empty directory where the spec file would be cannot be removed as a file.
+	specName := cdiapi.GenerateTransientSpecName(cdiVendor, cdiClass, "bad")
+	dir := filepath.Join(cdiRoot, specName+".yaml")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keep"), nil, 0o600))
+
+	require.ErrorContains(t, s.reconcileCDISpecs(), "unable to remove the CDI spec")
+}
+
+func TestLoadCheckpointRejectsCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	cm, err := checkpointmanager.NewCheckpointManager(dir)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, DriverPluginCheckpointFile), []byte(`{"checksum":1,"v1":{}}`), 0o600))
+
+	s := &DeviceState{checkpointManager: cm}
+	_, err = s.loadCheckpoint()
+	require.ErrorContains(t, err, "unable to sync from checkpoint")
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -95,6 +95,17 @@ kubectl describe pod <name>
 2. Verify CDI specs are being written to the configured path (default: `/var/run/cdi`).
 3. Check kubelet logs on the node for DRA-related errors.
 
+### Container fails with `unresolvable CDI devices` after a driver restart or node reboot
+
+**Symptom:** `kubectl describe pod` shows `CreateContainerError` with `CDI device injection failed: unresolvable CDI devices k8s.gpu.amd.com/gpu=<claim-uid>-...`, while the ResourceClaim still reports `allocated,reserved`.
+
+**Cause:** The claim's CDI spec under the CDI path (default `/var/run/cdi`, usually tmpfs) is gone, while the driver's checkpoint still lists the claim as prepared. The kubelet does not prepare an already-prepared claim again while it keeps running, so nothing rewrites the spec until the driver starts.
+
+**Resolution:**
+1. Restart the driver pod on the node. On startup the driver rebuilds the spec of every checkpointed claim whose device nodes still match the host and logs `Rebuilt the CDI spec for checkpointed claim <claim-uid>`.
+2. If the log instead shows `Removing the CDI spec for claim <claim-uid>, whose checkpoint entry can no longer be rebuilt`, the device nodes changed since the claim was prepared (for example a reboot renumbered `/dev/dri`). Delete and recreate the pod so the claim is prepared again; a `NodePrepareResources` error for the claim that says `recreate the pod` points at the same action.
+3. If the log shows `Leaving the CDI spec for claim <claim-uid> as is`, discovery did not find the claim's device on this start. Check the discovery errors earlier in the log.
+
 ### Partition-related issues
 
 **Symptom:** Partition devices do not appear in ResourceSlices, or partition claims remain Pending.
@@ -113,6 +124,7 @@ kubectl describe pod <name>
 - **Kubernetes 1.32+ required:** The DRA APIs used by this driver require Kubernetes 1.32 or later. The specific API version (`v1`, `v1beta2`, `v1beta1`) varies by Kubernetes version — the Helm chart auto-detects this.
 - **Sysfs-dependent attributes:** Device attributes are read from sysfs at discovery time. Attributes not exposed by the kernel driver or hardware will not appear in ResourceSlices. Documentation and examples may reference attributes that are not available on all GPU models.
 - **Unreadable VRAM:** When sysfs does not report a valid VRAM size, the driver publishes `memory: 0` and logs a warning. Memory-aware claims should require a positive capacity behind an existence guard (see the selector example in the driver attributes reference). Restart the driver after correcting the underlying sysfs/driver issue so discovery runs again.
+- **Prepared claims do not survive a device renumbering:** Device names are built from DRM minors (`gpu-<card>-<render>`), which the kernel assigns dynamically. When a reboot, module reload, or repartition renumbers a device node, the driver refuses to prepare the claims recorded against the old numbers and logs that their checkpoint entries can no longer be rebuilt; recreate those pods so the scheduler allocates against the current devices. Unchanged numbers are not proof that a name still refers to the same physical GPU.
 
 ## Reporting issues
 


### PR DESCRIPTION
On a plugin restart the CDI spec directory, usually tmpfs, can be wiped while the checkpoint survives, so a container can no longer resolve its devices. The driver never rebuilt those specs. This rebuilds them at startup from the checkpoint, re-ensures them on a checkpoint-hit `Prepare`, and hardens the paths that read checkpointed data. Addresses the same-boot half of #75; the reboot case is tracked in #83 and #86.

## Change

Reconcile reads the checkpoint at startup and rebuilds each claim's CDI spec. Before a spec is rebuilt, every checkpointed device node is verified against the host: a node that no longer resolves, changed type, or moved to different numbers marks the entry stale. CDI allows a node to carry only a path, resolving the host path from `Path` and leaving the numbers to the runtime, and the VFIO path emits exactly that, so those are verified by path rather than skipped.

Reconcile never drops a checkpoint entry. What it does with an entry depends on what kubelet will do with the claim, and that differs by case. While kubelet keeps running it does not call `Prepare` again for a claim it already prepared, so the entry is all a later `Unprepare` has to go on. Its prepared flag is in memory only, so after a kubelet restart or a node reboot it does call `Prepare` again, and that call must not replay stale state.

So an entry that cannot be rebuilt, because it is malformed or because its device nodes no longer match the host, is quarantined: its spec is removed, so the runtime cannot resolve the claim to nodes that may now back another GPU, and startup carries on for the other claims. A later checkpoint-hit `Prepare` for it validates the entry against the host again and fails with an error that says to recreate the pod, rather than replaying the stored numbers or re-resolving names that may now belong to other GPUs (#83). Failing startup instead was considered and not done: it takes every GPU on the node down for one bad entry, and kubelet cannot unprepare anything through a plugin that will not start, so the pod could not be deleted either.

An entry whose devices are merely absent from the current inventory keeps whatever spec it has and is skipped. Its nodes have already been verified, so an existing spec is as good as before the restart, and absence is routinely temporary: discovery can be incomplete, and an on-demand VFIO conversion brings the device back under another name. This branch does not restore a spec that is already missing. A CDI write error fails startup, because that is not self-healing and kubelet may never call `Prepare` for the claim again.

`Unprepare` stays lenient. It is the only way a pod's claims get released, so an entry it cannot act on, malformed or naming a device that has left the inventory, is dropped with a warning instead of returned as an error that kubelet retries forever. Host state left behind by the second case is #94.

The rest is defensive. Corrupt checkpoint content is rejected before it reaches CDI: a nil payload, a nil or nameless device, hollow `ContainerEdits`, edits that grant no device node, and nil entries inside `DeviceNodes`, `Hooks`, `Mounts` or `NetDevices`, which CDI dereferences before validating. `CreateClaimSpecFile` checks the inner `ContainerEdits` pointer itself rather than relying on its callers, because the fresh `Prepare` path does not go through the checkpoint validation. `Prepare`, `Unprepare` and reconcile load the checkpoint through one helper that rejects a null `v1` payload and initializes a null `preparedClaims` map before anything assigns into it, and a checkpoint-hit `Prepare` also ensures the common spec, which the response it returns always names. Each spec rebuilt at startup is logged with its claim and devices, and the troubleshooting guide gains an entry for the symptom.

## What was removed, and why

An earlier revision recorded the boot id next to the checkpoint and discarded the checkpoint when it changed. That is out again.

It could not do the job. A checkpoint-hit `Prepare` returns the stored devices without rewriting the checkpoint, so a binary that only serves an existing claim leaves the bytes, and any checksum over them, identical. If such a binary handles a `Prepare` in a new boot, kubelet marks the claim prepared again while the recorded epoch still names the old boot, and the discard would delete state kubelet is relying on. Distinguishing that needs something tied to kubelet's own prepared generation.

Discarding was unsafe for a second reason as well. The ResourceClaim still names `gpu-<card>-<render>`, so a fresh `Prepare` after a discard can resolve that name to a different PCI device. That is #83.

So the boot comparison, the discard, and the record that fed them are gone, and what is left is the part that does not need to know which boot it is in. The design for the rest, including a versioned recovery record, a generation identity, and type-aware VFIO recovery, belongs in #86.

## Scope

This covers a plugin restart within a boot, and makes a checkpoint-hit `Prepare` after a kubelet restart or reboot safe to the extent the checkpoint can be checked against the host. It does not tell two physical GPUs apart when the device numbers are unchanged, which needs #83, so a reboot that keeps the numbers rebuilds the specs without proving the claim still points at the same GPU.

It does not continuously reconcile the CDI directory. If a spec disappears while the plugin and kubelet keep running, retrying container creation alone does not trigger recovery; startup reconciliation needs a plugin restart. Host state beyond the CDI spec is not restored either: a device converted to VFIO on demand is skipped here rather than recovered, and its conversion record is separately lost on any second `Prepare`, which is #94.

## Tests

Rebuild on a same-boot restart; the checkpoint preserved rather than discarded; a renumbered, missing, or path-only node that no longer resolves quarantined with its spec removed, its entry kept, and its checkpoint-hit `Prepare` failing; a malformed entry losing its stale spec while keeping its checkpoint state; an entry absent from the inventory keeping its existing spec and not being rebuilt; one bad claim not blocking a good one; a CDI write error failing startup; corrupt, hollow, no-device-node and nested-null entries rejected with the message each fails on; every branch of the device-node check; the explicit-null `v1` and `preparedClaims` shapes that only a hand-edited checkpoint produces, and a corrupt file; a checkpoint-hit `Prepare` recreating a deleted spec, and failing when the claim or common spec cannot be written; a stale spec that cannot be removed failing startup; and `Unprepare` dropping a malformed entry instead of panicking and releasing a claim whose device is missing from the inventory. A fuzz target drives arbitrary JSON through the validation and the spec writer; a minute of fuzzing found nothing.

Each fail-closed case fails against the code without it, including the path-only verification, which passes if those nodes are skipped the way they used to be, and each quarantine case fails if the node check is skipped or the stale spec is left in place.

Rebased onto `develop` at 89b4b29. `make check` with the golangci-lint version the shared workflow pins (v1.64.8), `go test ./...` and `go test -race` pass locally on the head, and the container image builds from it with the Dockerfile's arguments.
