### PR TITLE
fix: set the common CDI spec node name from the --node-name flag

### DIFF
--- a/cmd/gpu-kubeletplugin/cdi.go
+++ b/cmd/gpu-kubeletplugin/cdi.go
@@ -34,7 +34,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/ROCm/k8s-gpu-dra-driver/pkg/consts"
 	klog "k8s.io/klog/v2"
@@ -53,7 +52,8 @@ const (
 )
 
 type CDIHandler struct {
-	cache *cdiapi.Cache
+	cache    *cdiapi.Cache
+	nodeName string
 }
 
 func NewCDIHandler(config *Config) (*CDIHandler, error) {
@@ -64,7 +64,8 @@ func NewCDIHandler(config *Config) (*CDIHandler, error) {
 		return nil, fmt.Errorf("unable to create a new CDI cache: %w", err)
 	}
 	handler := &CDIHandler{
-		cache: cache,
+		cache:    cache,
+		nodeName: config.flags.nodeName,
 	}
 
 	return handler, nil
@@ -78,7 +79,7 @@ func (cdi *CDIHandler) CreateCommonSpecFile() error {
 				Name: cdiCommonDeviceName,
 				ContainerEdits: cdispec.ContainerEdits{
 					Env: []string{
-						fmt.Sprintf("KUBERNETES_NODE_NAME=%s", os.Getenv("NODE_NAME")),
+						fmt.Sprintf("KUBERNETES_NODE_NAME=%s", cdi.nodeName),
 						fmt.Sprintf("DRA_RESOURCE_DRIVER_NAME=%s", consts.DriverName),
 					},
 				},

--- a/cmd/gpu-kubeletplugin/cdi_test.go
+++ b/cmd/gpu-kubeletplugin/cdi_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
+)
+
+// The common CDI spec must carry the node name that the driver parsed into its
+// config flag, not whatever NODE_NAME happens to be in the process environment,
+// so it stays consistent with the kubeletplugin and the ResourceSlice pool. The
+// test drives NewCDIHandler so it guards the config -> handler -> spec wiring, and
+// sets a conflicting NODE_NAME to prove the environment no longer wins.
+func TestCreateCommonSpecFileUsesConfiguredNodeName(t *testing.T) {
+	t.Setenv("NODE_NAME", "node-from-environment")
+
+	cdiRoot := t.TempDir()
+	config := &Config{
+		flags: &Flags{
+			cdiRoot:  cdiRoot,
+			nodeName: "node-from-config",
+		},
+	}
+
+	handler, err := NewCDIHandler(config)
+	require.NoError(t, err)
+	require.NoError(t, handler.CreateCommonSpecFile())
+
+	entries, err := os.ReadDir(cdiRoot)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	spec, err := cdiapi.ReadSpec(filepath.Join(cdiRoot, entries[0].Name()), 0)
+	require.NoError(t, err)
+	require.Len(t, spec.Devices, 1)
+
+	require.Contains(t, spec.Devices[0].ContainerEdits.Env, "KUBERNETES_NODE_NAME=node-from-config")
+	require.NotContains(t, spec.Devices[0].ContainerEdits.Env, "KUBERNETES_NODE_NAME=node-from-environment")
+}


### PR DESCRIPTION
## Motivation

`CreateCommonSpecFile` reads `KUBERNETES_NODE_NAME` from `os.Getenv("NODE_NAME")`, while the rest of the driver uses the `--node-name` flag (`config.flags.nodeName`) for the kubeletplugin node name and the ResourceSlice pool key. The flag is required and also reads the `NODE_NAME` env, so when it is set through the flag without the env the common spec carries an empty node name that disagrees with the rest of the driver.

## Change

Store the flag value on the CDI handler and use it in the common spec, so the node name is sourced consistently. A unit test builds the common spec with a known node name and checks it appears in the written spec.
