### PR TITLE
fix: report 0 for unreadable VRAM instead of a fabricated capacity

### DIFF
--- a/cmd/gpu-kubeletplugin/deviceinfo_test.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+// A memory capacity of 0 is the unreadable-VRAM sentinel. Both device types must
+// publish the key with a zero value, so positive memory selectors fail closed
+// rather than erroring on an absent field. This locks the ResourceSlice the
+// scheduler actually sees, not just the getMemoryBytes helper.
+func TestZeroMemoryCapacityIsPublished(t *testing.T) {
+	fullGPU := (&AmdGpuInfo{
+		MemoryBytes: 0,
+	}).GetDevice()
+
+	partition := (&AmdPartitionInfo{
+		Parent:      &AmdGpuInfo{},
+		MemoryBytes: 0,
+	}).GetDevice()
+
+	for name, device := range map[string]resourceapi.Device{
+		"full GPU":  fullGPU,
+		"partition": partition,
+	} {
+		t.Run(name, func(t *testing.T) {
+			memory, ok := device.Capacity["memory"]
+			require.True(t, ok)
+			require.True(t, memory.Value.IsZero())
+		})
+	}
+}

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -61,14 +61,14 @@ func extractTopologyInfo(gpuInfoMap map[string]interface{}) (simdUnits, computeU
 	return
 }
 
-// Helper function to get memory bytes with fallback
-func getMemoryBytes(gpuInfoMap map[string]interface{}, defaultBytes uint64, deviceType, pciAddr string) uint64 {
+// getMemoryBytes returns the device VRAM in bytes. 0 is a sentinel for unreadable
+// VRAM, not a measured capacity; discovery re-runs on restart.
+func getMemoryBytes(gpuInfoMap map[string]interface{}, deviceType, pciAddr string) uint64 {
 	if vramBytes, ok := gpuInfoMap["vramBytes"].(uint64); ok && vramBytes > 0 {
 		return vramBytes
 	}
-	// Fallback to default if VRAM parsing failed
-	klog.Warningf("VRAM info not available for %s %s, using default %dGB", deviceType, pciAddr, defaultBytes/(1024*1024*1024))
-	return defaultBytes
+	klog.Warningf("VRAM info not available for %s %s, reporting 0", deviceType, pciAddr)
+	return 0
 }
 
 func getPcieInfo(gpuInfoMap map[string]interface{}) (deviceattribute.DeviceAttribute, deviceattribute.DeviceAttribute, string, error) {
@@ -124,7 +124,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 				SimdUnits:        simdUnits,
 				ComputeUnits:     computeUnits,
 				NumaNode:         gpuInfoMap["numaNode"].(int),
-				MemoryBytes:      getMemoryBytes(gpuInfoMap, 80*1024*1024*1024, "device", pciAddr),
+				MemoryBytes:      getMemoryBytes(gpuInfoMap, "device", pciAddr),
 			}
 
 			// Create allocatable device for the full GPU
@@ -158,7 +158,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 				SimdUnits:        simdUnits,
 				ComputeUnits:     computeUnits,
 				NumaNode:         gpuInfoMap["numaNode"].(int),
-				MemoryBytes:      getMemoryBytes(gpuInfoMap, 20*1024*1024*1024, "partition", pciAddr),
+				MemoryBytes:      getMemoryBytes(gpuInfoMap, "partition", pciAddr),
 			}
 
 			// Create allocatable device for the partition

--- a/cmd/gpu-kubeletplugin/discovery_test.go
+++ b/cmd/gpu-kubeletplugin/discovery_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMemoryBytes(t *testing.T) {
+	withVram := map[string]interface{}{"vramBytes": uint64(16 * 1024 * 1024 * 1024)}
+	assert.Equal(t, uint64(16*1024*1024*1024), getMemoryBytes(withVram, "device", "0000:00:00.0"))
+
+	// Unreadable VRAM reports 0 instead of a fabricated capacity.
+	assert.Equal(t, uint64(0), getMemoryBytes(map[string]interface{}{}, "device", "0000:00:00.0"))
+	assert.Equal(t, uint64(0), getMemoryBytes(map[string]interface{}{"vramBytes": uint64(0)}, "partition", "0000:00:00.0"))
+}

--- a/docs/driver-attributes.md
+++ b/docs/driver-attributes.md
@@ -2,7 +2,7 @@
 
 This document summarizes what the AMD GPU DRA driver exposes through
 Kubernetes Dynamic Resource Allocation (DRA) ResourceSlices and how to
-interpret those attributes when selecting devices.
+interpret those attributes and capacities when selecting devices.
 
 The driver discovers AMD GPUs present on a node and advertises them as DRA
 Devices. It supports:
@@ -44,10 +44,28 @@ The following attributes are attached to each full GPU device:
   `pci0000:00`). Standard Kubernetes attribute for topology-aware scheduling.
 
 Capacity values for full GPUs:
-- `memory` (quantity, bytes): Advertised VRAM size; if the underlying topology
-  inspection cannot determine VRAM precisely, a conservative default is used
+- `memory` (quantity, bytes): Advertised VRAM size. When VRAM cannot be read, the
+  driver publishes `0`. Zero is a sentinel for an unknown/unreadable value, not a
+  measured physical capacity.
 - `computeUnits` (quantity): Number of compute units (CUs)
 - `simdUnits` (quantity): Number of SIMD units
+
+Workloads which require a minimum amount of VRAM should explicitly select a
+positive capacity, and should guard the reference so the selector does not abort
+allocation on a device that has no `memory` capacity:
+
+```cel
+cel.bind(cap, device.capacity["gpu.amd.com"],
+  has(cap.memory) && cap.memory.compareTo(quantity("16Gi")) >= 0)
+```
+
+A selector that references a capacity a device does not publish is an evaluation
+error that aborts the whole allocation, not a simple non-match, so the
+`has(cap.memory)` guard keeps the selector robust as other device types are
+added. This driver always publishes `memory` (`0` when unreadable), so the guard
+is precautionary here and matters mainly for capacities other drivers may leave
+unset. Devices with unknown VRAM remain allocatable to claims which do not
+reference memory.
 
 ## Attributes for a partition
 
@@ -65,7 +83,8 @@ The following attributes are attached to each GPU partition device:
 - `resource.kubernetes.io/pcieRoot` (string): parent's PCIe root complex
 
 Capacity values for partitions:
-- `memory` (quantity, bytes): VRAM capacity attributed to the partition
+- `memory` (quantity, bytes): VRAM capacity attributed to the partition, or `0`
+  when it cannot be read (the same unknown/unreadable sentinel as for full GPUs)
 - `computeUnits` (quantity): number of CUs attributed to the partition
 - `simdUnits` (quantity): number of SIMD units attributed to the partition
 
@@ -98,8 +117,9 @@ spec:
             expression: 'device.attributes["gpu.amd.com"].type == "amdgpu-partition"'
 ```
 
-You may also combine with other attributes (e.g., `memory`, `deviceID`,
-`productName`, or the PCIe topology attributes) depending on scheduling needs.
+You may also combine with capacities and other attributes (e.g., the `memory`
+capacity, or the `deviceID`, `productName`, and PCIe topology attributes)
+depending on scheduling needs.
 
 ### Request multiple partitions from the same parent GPU
 
@@ -197,8 +217,10 @@ selectors:
   scheduling.
 - NUMA node discovery: the driver reads the NUMA node for each GPU from sysfs
   and exposes it as an integer attribute for NUMA-aware scheduling.
-- Defaults: when certain metrics (like VRAM) cannot be read reliably, the
-  driver falls back to conservative defaults to remain usable.
+- Unreadable metrics: when VRAM cannot be read reliably, the driver publishes a
+  `memory` capacity of `0` (a sentinel for unknown, not a real size) rather than
+  guessing. Memory-aware claims should require a positive capacity behind an
+  existence guard (see the selector example above).
 
 If you need additional attributes or different representations, please open an
 issue discussing your use case.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,7 +65,7 @@ kubectl describe pod <name>
    kubectl get resourceslice <name> -o yaml
    ```
 2. Adjust your CEL selectors to reference only attributes that are present.
-3. Check driver logs for warnings like `VRAM info not available` which indicate fallback values are being used.
+3. Check driver logs for `VRAM info not available ... reporting 0`. The corresponding ResourceSlice keeps the `memory` capacity key with a value of zero. This indicates that VRAM discovery failed; it does not mean that the GPU physically has no memory.
 
 ### ResourceClaim stuck Pending
 
@@ -112,7 +112,7 @@ kubectl describe pod <name>
 - **No dynamic GPU partitioning:** GPUs must be pre-partitioned before driver deployment. The driver discovers existing partitions but does not create, modify, or remove them.
 - **Kubernetes 1.32+ required:** The DRA APIs used by this driver require Kubernetes 1.32 or later. The specific API version (`v1`, `v1beta2`, `v1beta1`) varies by Kubernetes version — the Helm chart auto-detects this.
 - **Sysfs-dependent attributes:** Device attributes are read from sysfs at discovery time. Attributes not exposed by the kernel driver or hardware will not appear in ResourceSlices. Documentation and examples may reference attributes that are not available on all GPU models.
-- **VRAM fallback:** When sysfs does not report VRAM size, the driver uses a default fallback value and logs a warning. The reported memory capacity may not reflect actual hardware in this case.
+- **Unreadable VRAM:** When sysfs does not report a valid VRAM size, the driver publishes `memory: 0` and logs a warning. Memory-aware claims should require a positive capacity behind an existence guard (see the selector example in the driver attributes reference). Restart the driver after correcting the underlying sysfs/driver issue so discovery runs again.
 
 ## Reporting issues
 


### PR DESCRIPTION
`getMemoryBytes` fell back to a fixed 80 GiB for a device and 20 GiB for a partition when the VRAM size could not be read, and that value was published as the `memory` device capacity. A scheduler selecting on `memory` could then match a device for a request up to the fabricated size, even though the real VRAM is unknown and may be smaller.

## Change

Report `memory: 0` when VRAM cannot be read. This keeps the capacity key while preventing positive minimum-memory selectors and capacity requests from treating an unknown value as available.

Claims which do not select or request memory may still allocate the device: the default DeviceClass shipped in this repo matches on `device.driver == "gpu.amd.com"` only, so a `memory: 0` device stays schedulable for memory-agnostic workloads while memory-sensitive ones fail closed. `0` is therefore an explicit sentinel for unknown/unreadable VRAM, not a measured physical capacity.

This implements the zero-capacity option discussed in #80. Omitting the field remains an alternative, but would require callers to guard CEL field access, because a reference to an absent capacity field can abort allocation.

## Docs and test

`docs/driver-attributes.md` and `docs/troubleshooting.md` still described the old fallback; both now define `0` as the unknown/unreadable sentinel and point memory-aware claims at a positive-capacity check. Discovery runs once at startup, so a restart is what re-reads VRAM after the underlying sysfs/driver issue is corrected.

The added test asserts the scheduler-facing contract directly: `GetDevice()` publishes the `memory` capacity key with a zero value for both full GPUs and partitions. The existing helper test only covered `getMemoryBytes`, which the scheduler never sees.

## Remaining cases

This removes the fabricated 80/20 GiB for absent or zero VRAM. It does not verify that a non-zero VRAM value belongs to the right device or the right memory heap; it stays scoped to the absent/zero fallback. Two adjacent paths are covered elsewhere:

- Borrowed topology (#79): a device with no `renderD` entry could borrow renderD 128's topology and carry a non-zero VRAM from another device, which passes the `vramBytes > 0` check here. #77 now fixes #79 by skipping devices that cannot resolve both a real card and render node, so that path is rejected upstream. The clean order is to merge #77 first, then rebase this PR.
- Wrong-but-positive VRAM (#84): discovery reads `mem_banks/0` `size_in_bytes` without checking `heap_type`. That holds for the single-local-bank dGPU path, but a multi-bank APU can expose a positive non-local bank at index 0, which the zero sentinel here does not catch. Tracked in #84.

Addresses #80. Related: #77, #79, #84.
