### PR TITLE
ci: auto-run PR image build for ROCm org members

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -47,13 +47,18 @@ jobs:
       registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  # Label-gated image build on PRs (build only, no push)
+  # Image build on PRs (build only, no push).
+  # Runs automatically for ROCm org members / collaborators; external
+  # contributors still require the 'ci-run' label.
   pr-build:
     name: PR Build
     if: >-
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'ci-run') &&
-      github.repository == 'ROCm/k8s-gpu-dra-driver'
+      github.repository == 'ROCm/k8s-gpu-dra-driver' &&
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'ci-run')
+      )
     uses: ROCm/common-infra-operator/.github/workflows/image-build-push.yaml@main
     with:
       image-registry: docker.io/amdpsdo


### PR DESCRIPTION
## Summary
- The `pr-build` job in `image.yaml` previously required the `ci-run` label on **every** PR, including those opened by ROCm org members and collaborators.
- This gates the job on `author_association` so that `OWNER` / `MEMBER` / `COLLABORATOR` PRs build automatically, while external contributors still require the `ci-run` label.
- The `github.repository == 'ROCm/k8s-gpu-dra-driver'` guard is preserved, so this only runs on the upstream repo.

## Behavior
- **ROCm org members / collaborators:** PR image build runs automatically on `opened` / `synchronize` / `reopened`.
- **External contributors:** unchanged — still require the `ci-run` label (the `labeled` trigger re-runs the build when the label is added).

## Notes
- `author_association` is provided directly on the PR event payload, so no API token or extra permissions are needed.
- Caveat: a private org member who has never been granted repo-level access can show as `CONTRIBUTOR`. If some members still don't auto-trigger, making their org membership public or adding them as collaborators resolves it without further workflow changes.

## Test plan
- [ ] Org-member PR triggers `PR Build` without a label
- [ ] External PR without `ci-run` label does **not** trigger the build
- [ ] External PR with `ci-run` label triggers the build