### PR TITLE
feat: KEP-4815 dual-entry advertising with per-VF capacity and sibling exclusion

### DIFF
--- a/cmd/gpu-kubeletplugin/allocatable.go
+++ b/cmd/gpu-kubeletplugin/allocatable.go
@@ -74,6 +74,22 @@ func (d *AllocatableDevice) GetPCIAddress() string {
 	return ""
 }
 
+// GetSiblingLookupPCIAddress returns the PCI address for finding sibling
+// devices (compute and VFIO on the same physical GPU). GIM VFs return ""
+// because they have different PCI addresses from the compute PF.
+func (d *AllocatableDevice) GetSiblingLookupPCIAddress() string {
+	switch d.Type() {
+	case consts.AmdGpuDeviceType:
+		return d.AmdGpu.PCIAddress
+	case consts.VfioDeviceType:
+		if d.Vfio.IsVF {
+			return ""
+		}
+		return d.Vfio.PCIAddress
+	}
+	return ""
+}
+
 // GetDevice returns the DRA Device representation for Kubernetes
 func (d *AllocatableDevice) GetDevice() resourceapi.Device {
 	switch d.Type() {

--- a/cmd/gpu-kubeletplugin/allocatable_test.go
+++ b/cmd/gpu-kubeletplugin/allocatable_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSiblingLookupPCIAddress(t *testing.T) {
+	tests := map[string]struct {
+		device   *AllocatableDevice
+		expected string
+	}{
+		"AmdGpu returns PCIAddress": {
+			device:   &AllocatableDevice{AmdGpu: &AmdGpuInfo{PCIAddress: "0000:0a:00.0"}},
+			expected: "0000:0a:00.0",
+		},
+		"VFIO PF returns PCIAddress": {
+			device:   &AllocatableDevice{Vfio: &AmdGpuVFIOInfo{PCIAddress: "0000:0a:00.0", IsVF: false}},
+			expected: "0000:0a:00.0",
+		},
+		"VFIO VF returns empty": {
+			device:   &AllocatableDevice{Vfio: &AmdGpuVFIOInfo{PCIAddress: "0000:0b:00.0", IsVF: true}},
+			expected: "",
+		},
+		"AmdPartition returns empty": {
+			device:   &AllocatableDevice{AmdPartition: &AmdPartitionInfo{Parent: &AmdGpuInfo{PCIAddress: "0000:0a:00.0"}}},
+			expected: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.device.GetSiblingLookupPCIAddress())
+		})
+	}
+}

--- a/cmd/gpu-kubeletplugin/deviceinfo.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ROCm/k8s-gpu-dra-driver/pkg/consts"
 
@@ -101,6 +102,8 @@ func (d *AmdGpuInfo) GetDevice() resourceapi.Device {
 }
 
 // AmdGpuVFIOInfo represents a GIM SR-IOV VF for VFIO passthrough
+const VFSlotCounterName = "vf-slots"
+
 type AmdGpuVFIOInfo struct {
 	PCIAddress         string
 	DeviceID           string
@@ -113,11 +116,80 @@ type AmdGpuVFIOInfo struct {
 	pciBusIDAttr       deviceattribute.DeviceAttribute
 	pcieRootAttr       deviceattribute.DeviceAttribute
 	preConfigureDriver string
+	ParentPFAddress    string
+	TotalVFs           int
+	NumVFs             int
+	MemoryBytes        uint64
+	ComputeUnits       int
+	SimdUnits          int
+}
+
+func (d *AmdGpuVFIOInfo) partitionMode() string {
+	switch d.NumVFs {
+	case 1:
+		return "spx"
+	case 2:
+		return "dpx"
+	case 3:
+		return "tpx"
+	case 4:
+		return "qpx"
+	case 8:
+		return "cpx"
+	default:
+		return ""
+	}
 }
 
 // CanonicalName returns the canonical name for this VFIO device
 func (d *AmdGpuVFIOInfo) CanonicalName() string {
 	return fmt.Sprintf("gpu-vfio-%d", d.Index)
+}
+
+func pciAddrToDNSLabel(addr string) string {
+	return strings.NewReplacer(":", "-", ".", "-").Replace(addr)
+}
+
+// GetSharedCounterSetName returns the KEP-4815 counter set name for the parent
+// PF of this VFIO device. Returns "" if this device has no SR-IOV capability.
+func (d *AmdGpuVFIOInfo) GetSharedCounterSetName() string {
+	if d.TotalVFs == 0 || d.ParentPFAddress == "" {
+		return ""
+	}
+	return fmt.Sprintf("pf-%s-counter-set", pciAddrToDNSLabel(d.ParentPFAddress))
+}
+
+// GetSharedCounterSet returns the KEP-4815 CounterSet for the parent PF.
+func (d *AmdGpuVFIOInfo) GetSharedCounterSet() *resourceapi.CounterSet {
+	name := d.GetSharedCounterSetName()
+	if name == "" {
+		return nil
+	}
+	return &resourceapi.CounterSet{
+		Name: name,
+		Counters: map[string]resourceapi.Counter{
+			VFSlotCounterName: {Value: *resource.NewQuantity(int64(d.TotalVFs), resource.BinarySI)},
+		},
+	}
+}
+
+// GetConsumesCounters returns the KEP-4815 counter consumption for this device.
+// VFs consume 1 vf-slot; PFs consume all vf-slots (mutually exclusive with VFs).
+func (d *AmdGpuVFIOInfo) GetConsumesCounters() []resourceapi.DeviceCounterConsumption {
+	name := d.GetSharedCounterSetName()
+	if name == "" {
+		return nil
+	}
+	consumed := int64(1)
+	if !d.IsVF {
+		consumed = int64(d.TotalVFs)
+	}
+	return []resourceapi.DeviceCounterConsumption{{
+		CounterSet: name,
+		Counters: map[string]resourceapi.Counter{
+			VFSlotCounterName: {Value: *resource.NewQuantity(consumed, resource.BinarySI)},
+		},
+	}}
 }
 
 // GetDevice returns the DRA Device representation for a VFIO passthrough GPU
@@ -144,10 +216,27 @@ func (d *AmdGpuVFIOInfo) GetDevice() resourceapi.Device {
 	if d.pcieRootAttr.Name != "" {
 		attributes[d.pcieRootAttr.Name] = d.pcieRootAttr.Value
 	}
-	return resourceapi.Device{
-		Name:       d.CanonicalName(),
-		Attributes: attributes,
+	if mode := d.partitionMode(); mode != "" {
+		attributes["partitionProfile"] = resourceapi.DeviceAttribute{StringValue: ptr.To(mode)}
 	}
+	dev := resourceapi.Device{
+		Name:             d.CanonicalName(),
+		Attributes:       attributes,
+		ConsumesCounters: d.GetConsumesCounters(),
+	}
+	if d.MemoryBytes > 0 || d.ComputeUnits > 0 || d.SimdUnits > 0 {
+		dev.Capacity = map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{}
+		if d.MemoryBytes > 0 {
+			dev.Capacity["memory"] = resourceapi.DeviceCapacity{Value: *resource.NewQuantity(int64(d.MemoryBytes), resource.BinarySI)}
+		}
+		if d.ComputeUnits > 0 {
+			dev.Capacity["computeUnits"] = resourceapi.DeviceCapacity{Value: *resource.NewQuantity(int64(d.ComputeUnits), resource.BinarySI)}
+		}
+		if d.SimdUnits > 0 {
+			dev.Capacity["simdUnits"] = resourceapi.DeviceCapacity{Value: *resource.NewQuantity(int64(d.SimdUnits), resource.BinarySI)}
+		}
+	}
+	return dev
 }
 
 // CanonicalName returns the canonical name for this partition

--- a/cmd/gpu-kubeletplugin/deviceinfo_test.go
+++ b/cmd/gpu-kubeletplugin/deviceinfo_test.go
@@ -17,12 +17,170 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/ROCm/k8s-gpu-dra-driver/pkg/consts"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 )
+
+func TestPartitionMode(t *testing.T) {
+	tests := []struct {
+		numVFs   int
+		expected string
+	}{
+		{1, "spx"},
+		{2, "dpx"},
+		{4, "qpx"},
+		{8, "cpx"},
+		{0, ""},
+		{3, "tpx"},
+		{16, ""},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("NumVFs=%d", tc.numVFs), func(t *testing.T) {
+			d := &AmdGpuVFIOInfo{NumVFs: tc.numVFs}
+			assert.Equal(t, tc.expected, d.partitionMode())
+		})
+	}
+}
+
+func TestGetSharedCounterSetName(t *testing.T) {
+	tests := map[string]struct {
+		totalVFs        int
+		parentPFAddress string
+		expected        string
+	}{
+		"PF with VFs": {
+			totalVFs:        4,
+			parentPFAddress: "0000:0a:00.0",
+			expected:        "pf-0000-0a-00-0-counter-set",
+		},
+		"TotalVFs=0": {
+			totalVFs:        0,
+			parentPFAddress: "0000:0a:00.0",
+			expected:        "",
+		},
+		"empty ParentPFAddress": {
+			totalVFs:        4,
+			parentPFAddress: "",
+			expected:        "",
+		},
+		"both zero/empty": {
+			totalVFs:        0,
+			parentPFAddress: "",
+			expected:        "",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := &AmdGpuVFIOInfo{TotalVFs: tc.totalVFs, ParentPFAddress: tc.parentPFAddress}
+			assert.Equal(t, tc.expected, d.GetSharedCounterSetName())
+		})
+	}
+}
+
+func TestGetSharedCounterSet(t *testing.T) {
+	t.Run("returns CounterSet when TotalVFs > 0", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{TotalVFs: 8, ParentPFAddress: "0000:0a:00.0"}
+		cs := d.GetSharedCounterSet()
+		require.NotNil(t, cs)
+		assert.Equal(t, "pf-0000-0a-00-0-counter-set", cs.Name)
+		counter, ok := cs.Counters[VFSlotCounterName]
+		require.True(t, ok)
+		assert.Equal(t, *resource.NewQuantity(8, resource.BinarySI), counter.Value)
+	})
+
+	t.Run("returns nil when TotalVFs = 0", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{TotalVFs: 0, ParentPFAddress: "0000:0a:00.0"}
+		assert.Nil(t, d.GetSharedCounterSet())
+	})
+}
+
+func TestGetConsumesCounters(t *testing.T) {
+	t.Run("VF consumes 1 slot", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{IsVF: true, TotalVFs: 8, ParentPFAddress: "0000:0a:00.0"}
+		cc := d.GetConsumesCounters()
+		require.Len(t, cc, 1)
+		counter := cc[0].Counters[VFSlotCounterName]
+		assert.Equal(t, *resource.NewQuantity(1, resource.BinarySI), counter.Value)
+	})
+
+	t.Run("PF consumes all slots", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{IsVF: false, TotalVFs: 4, ParentPFAddress: "0000:0a:00.0"}
+		cc := d.GetConsumesCounters()
+		require.Len(t, cc, 1)
+		counter := cc[0].Counters[VFSlotCounterName]
+		assert.Equal(t, *resource.NewQuantity(4, resource.BinarySI), counter.Value)
+	})
+
+	t.Run("returns nil when TotalVFs = 0", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{IsVF: false, TotalVFs: 0}
+		assert.Nil(t, d.GetConsumesCounters())
+	})
+}
+
+func TestVFIOGetDevice(t *testing.T) {
+	t.Run("Attributes", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{
+			PCIAddress:  "0000:0b:00.0",
+			DeviceID:    "0x740f",
+			VendorID:    consts.AMDVendorID,
+			IOMMUGroup:  "42",
+			ProductName: "MI300X",
+			NumaNode:    1,
+			IsVF:        true,
+			NumVFs:      4,
+		}
+		dev := d.GetDevice()
+		assert.Equal(t, ptr.To(consts.VfioDeviceType), dev.Attributes["type"].StringValue)
+		assert.Equal(t, ptr.To("42"), dev.Attributes["iommuGroup"].StringValue)
+		assert.Equal(t, ptr.To("0000:0b:00.0"), dev.Attributes["pciAddr"].StringValue)
+		assert.Equal(t, ptr.To(true), dev.Attributes["isVF"].BoolValue)
+		assert.Equal(t, ptr.To("MI300X"), dev.Attributes["productName"].StringValue)
+		assert.Equal(t, ptr.To(int64(1)), dev.Attributes["numaNode"].IntValue)
+		assert.Equal(t, ptr.To("qpx"), dev.Attributes["partitionProfile"].StringValue)
+	})
+
+	t.Run("CapacityPresent", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{
+			MemoryBytes:  51539607552,
+			ComputeUnits: 76,
+			SimdUnits:    304,
+		}
+		dev := d.GetDevice()
+		require.NotNil(t, dev.Capacity)
+		assert.Equal(t, *resource.NewQuantity(51539607552, resource.BinarySI), dev.Capacity["memory"].Value)
+		assert.Equal(t, *resource.NewQuantity(76, resource.BinarySI), dev.Capacity["computeUnits"].Value)
+		assert.Equal(t, *resource.NewQuantity(304, resource.BinarySI), dev.Capacity["simdUnits"].Value)
+	})
+
+	t.Run("CapacityAbsent", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{
+			PCIAddress: "0000:0b:00.0",
+			IOMMUGroup: "42",
+		}
+		dev := d.GetDevice()
+		assert.Nil(t, dev.Capacity)
+	})
+
+	t.Run("ConsumesCounters", func(t *testing.T) {
+		d := &AmdGpuVFIOInfo{
+			IsVF:            true,
+			TotalVFs:        8,
+			ParentPFAddress: "0000:0a:00.0",
+		}
+		dev := d.GetDevice()
+		require.Len(t, dev.ConsumesCounters, 1)
+		assert.Equal(t, "pf-0000-0a-00-0-counter-set", dev.ConsumesCounters[0].CounterSet)
+	})
+}
 
 // A memory capacity of 0 is the unreadable-VRAM sentinel. Both device types must
 // publish the key with a zero value, so positive memory selectors fail closed

--- a/cmd/gpu-kubeletplugin/discovery.go
+++ b/cmd/gpu-kubeletplugin/discovery.go
@@ -88,6 +88,7 @@ func getPcieInfo(gpuInfoMap map[string]interface{}) (deviceattribute.DeviceAttri
 
 func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 	alldevices := make(AllocatableDevices)
+	vfioIndex := 0
 	allAMDGPUs := amdgpu.GetAMDGPUs()
 
 	for pciAddr, gpuInfoMap := range allAMDGPUs {
@@ -137,6 +138,31 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 
 			klog.Infof("Found full AMD GPU: %s, compute type: %s, memory type: %s",
 				device.CanonicalName(), computePartitionType, memoryPartitionType)
+
+			if featuregates.Enabled(featuregates.VFIOPassthrough) {
+				iommuGroup, _ := amdgpu.GetIOMMUGroup(pciAddr)
+				vfioSibling := &AmdGpuVFIOInfo{
+					PCIAddress:      pciAddr,
+					DeviceID:        amdGpuInfo.DeviceID,
+					VendorID:        consts.AMDVendorID,
+					ProductName:     amdGpuInfo.ProductName,
+					NumaNode:        amdGpuInfo.NumaNode,
+					IsVF:            false,
+					Index:           vfioIndex,
+					IOMMUGroup:      iommuGroup,
+					pciBusIDAttr:    pciBusIDAttr,
+					pcieRootAttr:    pcieRootAttr,
+					ParentPFAddress: pciAddr,
+					TotalVFs:        amdgpu.ReadSRIOVTotalVFs(pciAddr),
+					MemoryBytes:     amdGpuInfo.MemoryBytes,
+					ComputeUnits:    amdGpuInfo.ComputeUnits,
+					SimdUnits:       amdGpuInfo.SimdUnits,
+				}
+				vfioDev := &AllocatableDevice{Vfio: vfioSibling}
+				alldevices[vfioDev.CanonicalName()] = vfioDev
+				klog.Infof("Found VFIO sibling for compute GPU: %s (PCI: %s, IOMMU: %s)", vfioDev.CanonicalName(), pciAddr, iommuGroup)
+				vfioIndex++
+			}
 		} else if computePartitionType != "" {
 			// This is a partition - create both parent GPU info and partition info
 
@@ -181,8 +207,6 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 	// Discover VFIO passthrough devices:
 	// - PFs already bound to vfio-pci by the GPU Operator (pf-passthrough mode)
 	// - GIM SR-IOV VFs (vf-passthrough mode)
-	vfioIndex := 0
-
 	if featuregates.Enabled(featuregates.VFIOPassthrough) {
 		pfMap, err := amdgpu.GetPFMapping()
 		if err != nil {
@@ -229,6 +253,7 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 		if err != nil {
 			klog.V(2).Infof("No VFIO VF devices found: %v", err)
 		} else {
+			pfCapCache := make(map[string][3]uint64)
 			vfKeys := make([]string, 0, len(vfMap))
 			for k := range vfMap {
 				vfKeys = append(vfKeys, k)
@@ -244,6 +269,18 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 					}
 					pciBusIDAttr, _ := deviceattribute.GetPCIBusIDAttribute(vf.PCIAddress)
 					currentDriver, _ := amdgpu.GetPCIDriver(vf.PCIAddress)
+					var memPerVF uint64
+					var cuPerVF, simdPerVF int
+					if vf.NumVFs > 0 {
+						cap, ok := pfCapCache[vf.ParentPCIAddress]
+						if !ok {
+							cap = amdgpu.ReadPFCapacity(vf.ParentPCIAddress)
+							pfCapCache[vf.ParentPCIAddress] = cap
+						}
+						memPerVF = cap[0] / uint64(vf.NumVFs)
+						cuPerVF = int(cap[1]) / vf.NumVFs
+						simdPerVF = int(cap[2]) / vf.NumVFs
+					}
 					device := &AmdGpuVFIOInfo{
 						PCIAddress:         vf.PCIAddress,
 						DeviceID:           vf.DeviceID,
@@ -256,9 +293,17 @@ func enumerateAllPossibleDevices() (AllocatableDevices, error) {
 						pciBusIDAttr:       pciBusIDAttr,
 						pcieRootAttr:       pcieRootAttr,
 						preConfigureDriver: currentDriver,
+						ParentPFAddress:    vf.ParentPCIAddress,
+						TotalVFs:           vf.TotalVFs,
+						NumVFs:             vf.NumVFs,
+						MemoryBytes:        memPerVF,
+						ComputeUnits:       cuPerVF,
+						SimdUnits:          simdPerVF,
 					}
 					alldevices[device.CanonicalName()] = &AllocatableDevice{Vfio: device}
-					klog.Infof("Found VFIO VF device: %s (PCI: %s, PF: %s, IOMMU: %s)", device.CanonicalName(), vf.PCIAddress, vf.ParentPCIAddress, vf.IOMMUGroup)
+					klog.Infof("Found VFIO VF device: %s (PCI: %s, PF: %s, IOMMU: %s, mode: %s, mem: %dMi, CU: %d)",
+						device.CanonicalName(), vf.PCIAddress, vf.ParentPCIAddress, vf.IOMMUGroup,
+						device.partitionMode(), memPerVF/(1024*1024), cuPerVF)
 					vfioIndex++
 				}
 			}

--- a/cmd/gpu-kubeletplugin/driver.go
+++ b/cmd/gpu-kubeletplugin/driver.go
@@ -40,6 +40,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sort"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,10 +61,12 @@ type driver struct {
 	state       *DeviceState
 	healthcheck *healthcheck
 	cancelCtx   func(error)
+	nodeName    string
 }
 
 func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	driver := &driver{
+		nodeName:  config.flags.nodeName,
 		client:    config.coreclient,
 		cancelCtx: config.cancelMainCtx,
 	}
@@ -94,18 +97,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 	driver.helper = helper
 
-	devices := resourceSliceDevices(state.allocatable)
-	resources := resourceslice.DriverResources{
-		Pools: map[string]resourceslice.Pool{
-			config.flags.nodeName: {
-				Slices: []resourceslice.Slice{
-					{
-						Devices: devices,
-					},
-				},
-			},
-		},
-	}
+	resources := driver.buildDriverResources(config.flags.nodeName)
 
 	if resourcesJSON, err := json.MarshalIndent(resources, "", "  "); err != nil {
 		klog.Warningf("Failed to marshal ResourceSlice to JSON: %v", err)
@@ -141,6 +133,59 @@ func resourceSliceDevices(allocatable AllocatableDevices) []resourceapi.Device {
 	return devices
 }
 
+func (d *driver) buildDriverResources(nodeName string) resourceslice.DriverResources {
+	devices := resourceSliceDevices(d.state.allocatable)
+	counterSets := d.collectVFIOCounterSets()
+
+	if len(counterSets) == 0 {
+		return resourceslice.DriverResources{
+			Pools: map[string]resourceslice.Pool{
+				nodeName: {
+					Slices: []resourceslice.Slice{
+						{Devices: devices},
+					},
+				},
+			},
+		}
+	}
+	return resourceslice.DriverResources{
+		Pools: map[string]resourceslice.Pool{
+			nodeName: {
+				Slices: []resourceslice.Slice{
+					{SharedCounters: counterSets},
+					{Devices: devices},
+				},
+			},
+		},
+	}
+}
+
+func (d *driver) collectVFIOCounterSets() []resourceapi.CounterSet {
+	counterSetsByPF := make(map[string]*resourceapi.CounterSet)
+	for _, device := range d.state.allocatable {
+		if device.Vfio == nil {
+			continue
+		}
+		cs := device.Vfio.GetSharedCounterSet()
+		if cs == nil {
+			continue
+		}
+		if _, seen := counterSetsByPF[device.Vfio.ParentPFAddress]; !seen {
+			counterSetsByPF[device.Vfio.ParentPFAddress] = cs
+		}
+	}
+	pfAddrs := make([]string, 0, len(counterSetsByPF))
+	for addr := range counterSetsByPF {
+		pfAddrs = append(pfAddrs, addr)
+	}
+	sort.Strings(pfAddrs)
+	var result []resourceapi.CounterSet
+	for _, addr := range pfAddrs {
+		result = append(result, *counterSetsByPF[addr])
+	}
+	return result
+}
+
 func (d *driver) Shutdown(logger klog.Logger) error {
 	if d.healthcheck != nil {
 		d.healthcheck.Stop(logger)
@@ -160,12 +205,15 @@ func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceap
 	return result, nil
 }
 
-func (d *driver) prepareResourceClaim(_ context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	preparedPBs, err := d.state.Prepare(claim)
+func (d *driver) prepareResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
+	preparedPBs, siblingChanged, err := d.state.Prepare(claim)
 	if err != nil {
 		return kubeletplugin.PrepareResult{
 			Err: fmt.Errorf("error preparing devices for claim %v: %w", claim.UID, err),
 		}
+	}
+	if siblingChanged {
+		d.republishResources(ctx)
 	}
 	var prepared []kubeletplugin.Device
 	for _, preparedPB := range preparedPBs {
@@ -209,12 +257,26 @@ func (d *driver) UnprepareResourceClaims(ctx context.Context, claims []kubeletpl
 	return result, nil
 }
 
-func (d *driver) unprepareResourceClaim(_ context.Context, claim kubeletplugin.NamespacedObject) error {
-	if err := d.state.Unprepare(string(claim.UID)); err != nil {
+func (d *driver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin.NamespacedObject) error {
+	siblingChanged, err := d.state.Unprepare(string(claim.UID))
+	if err != nil {
 		return fmt.Errorf("error unpreparing devices for claim %v: %w", claim.UID, err)
 	}
-
+	if siblingChanged {
+		d.republishResources(ctx)
+	}
 	return nil
+}
+
+func (d *driver) republishResources(ctx context.Context) {
+	d.state.Lock()
+	resources := d.buildDriverResources(d.nodeName)
+	d.state.Unlock()
+	if err := d.helper.PublishResources(ctx, resources); err != nil {
+		klog.Warningf("Failed to republish resources after sibling change: %v", err)
+	} else {
+		klog.Infof("Republished ResourceSlice after sibling change")
+	}
 }
 
 func (d *driver) HandleError(ctx context.Context, err error, msg string) {

--- a/cmd/gpu-kubeletplugin/driver_test.go
+++ b/cmd/gpu-kubeletplugin/driver_test.go
@@ -20,6 +20,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	resourceapi "k8s.io/api/resource/v1"
 )
 
@@ -29,6 +31,71 @@ func deviceNames(devices []resourceapi.Device) []string {
 		names[i] = d.Name
 	}
 	return names
+}
+
+func TestCollectVFIOCounterSets(t *testing.T) {
+	t.Run("deduplicates VFs from same PF", func(t *testing.T) {
+		d := &driver{state: &DeviceState{
+			allocatable: AllocatableDevices{
+				"gpu-vfio-0": {Vfio: &AmdGpuVFIOInfo{Index: 0, IsVF: true, TotalVFs: 4, ParentPFAddress: "0000:0a:00.0"}},
+				"gpu-vfio-1": {Vfio: &AmdGpuVFIOInfo{Index: 1, IsVF: true, TotalVFs: 4, ParentPFAddress: "0000:0a:00.0"}},
+				"gpu-0-128":  {AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128}},
+			},
+		}}
+		sets := d.collectVFIOCounterSets()
+		assert.Len(t, sets, 1)
+		assert.Equal(t, "pf-0000-0a-00-0-counter-set", sets[0].Name)
+	})
+
+	t.Run("multiple PFs produce multiple sets sorted by address", func(t *testing.T) {
+		d := &driver{state: &DeviceState{
+			allocatable: AllocatableDevices{
+				"gpu-vfio-0": {Vfio: &AmdGpuVFIOInfo{Index: 0, IsVF: true, TotalVFs: 4, ParentPFAddress: "0000:0b:00.0"}},
+				"gpu-vfio-1": {Vfio: &AmdGpuVFIOInfo{Index: 1, IsVF: false, TotalVFs: 8, ParentPFAddress: "0000:0a:00.0"}},
+			},
+		}}
+		sets := d.collectVFIOCounterSets()
+		assert.Len(t, sets, 2)
+		assert.Equal(t, "pf-0000-0a-00-0-counter-set", sets[0].Name)
+		assert.Equal(t, "pf-0000-0b-00-0-counter-set", sets[1].Name)
+	})
+
+	t.Run("no VFIO devices returns empty", func(t *testing.T) {
+		d := &driver{state: &DeviceState{
+			allocatable: AllocatableDevices{
+				"gpu-0-128": {AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128}},
+			},
+		}}
+		sets := d.collectVFIOCounterSets()
+		assert.Empty(t, sets)
+	})
+}
+
+func TestBuildDriverResourcesWithCounters(t *testing.T) {
+	t.Run("with counters has 2 slices", func(t *testing.T) {
+		d := &driver{state: &DeviceState{
+			allocatable: AllocatableDevices{
+				"gpu-vfio-0": {Vfio: &AmdGpuVFIOInfo{Index: 0, IsVF: false, TotalVFs: 4, ParentPFAddress: "0000:0a:00.0", IOMMUGroup: "42", PCIAddress: "0000:0a:00.0"}},
+			},
+		}}
+		res := d.buildDriverResources("test-node")
+		pool := res.Pools["test-node"]
+		assert.Len(t, pool.Slices, 2, "should have SharedCounters slice + Devices slice")
+		assert.NotEmpty(t, pool.Slices[0].SharedCounters)
+		assert.NotEmpty(t, pool.Slices[1].Devices)
+	})
+
+	t.Run("without counters has 1 slice", func(t *testing.T) {
+		d := &driver{state: &DeviceState{
+			allocatable: AllocatableDevices{
+				"gpu-0-128": {AmdGpu: &AmdGpuInfo{cardIndex: 0, renderIndex: 128}},
+			},
+		}}
+		res := d.buildDriverResources("test-node")
+		pool := res.Pools["test-node"]
+		assert.Len(t, pool.Slices, 1, "should have only Devices slice")
+		assert.NotEmpty(t, pool.Slices[0].Devices)
+	})
 }
 
 func TestResourceSliceDevicesAreSortedByName(t *testing.T) {

--- a/cmd/gpu-kubeletplugin/state.go
+++ b/cmd/gpu-kubeletplugin/state.go
@@ -85,6 +85,8 @@ type DeviceState struct {
 	checkpointManager    checkpointmanager.CheckpointManager
 	vfioManager          *VfioPciManager
 	claimVfioConversions map[string]*AmdGpuInfo
+	byPCIAddress         map[string][]string
+	siblingCache         map[string]*AllocatableDevice
 }
 
 func NewDeviceState(config *Config) (*DeviceState, error) {
@@ -128,7 +130,9 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 		allocatable:       allocatable,
 		vfioManager:       vfioMgr,
 		checkpointManager: checkpointManager,
+		siblingCache:      make(map[string]*AllocatableDevice),
 	}
+	state.buildPCIIndex()
 
 	checkpoints, err := state.checkpointManager.ListCheckpoints()
 	if err != nil {
@@ -149,7 +153,7 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 	return state, nil
 }
 
-func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Device, error) {
+func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Device, bool, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -157,60 +161,88 @@ func (s *DeviceState) Prepare(claim *resourceapi.ResourceClaim) ([]*drapbv1.Devi
 
 	checkpoint := newCheckpoint()
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
-		return nil, fmt.Errorf("unable to sync from checkpoint: %v", err)
+		return nil, false, fmt.Errorf("unable to sync from checkpoint: %v", err)
 	}
 	preparedClaims := checkpoint.V1.PreparedClaims
 
 	if preparedClaims[claimUID] != nil {
-		return preparedClaims[claimUID].GetDevices(), nil
+		return preparedClaims[claimUID].GetDevices(), false, nil
 	}
 
 	preparedDevices, err := s.prepareDevices(claim)
 	if err != nil {
-		return nil, fmt.Errorf("prepare failed: %v", err)
+		return nil, false, fmt.Errorf("prepare failed: %v", err)
 	}
 
 	if err = s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
-		return nil, fmt.Errorf("unable to create CDI spec file for claim: %v", err)
+		return nil, false, fmt.Errorf("unable to create CDI spec file for claim: %v", err)
+	}
+
+	siblingChanged := false
+	for _, pd := range preparedDevices {
+		if allocDev, exists := s.allocatable[pd.DeviceName]; exists {
+			if allocDev.GetSiblingLookupPCIAddress() != "" {
+				s.RemoveSiblingDevices(pd.DeviceName, allocDev)
+				siblingChanged = true
+			}
+		}
 	}
 
 	preparedClaims[claimUID] = preparedDevices
 	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
-		return nil, fmt.Errorf("unable to sync to checkpoint: %v", err)
+		for _, pd := range preparedDevices {
+			if allocDev, exists := s.allocatable[pd.DeviceName]; exists {
+				if allocDev.GetSiblingLookupPCIAddress() != "" {
+					s.RestoreSiblingDevices(allocDev)
+				}
+			}
+		}
+		return nil, false, fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 
-	return preparedClaims[claimUID].GetDevices(), nil
+	return preparedClaims[claimUID].GetDevices(), siblingChanged, nil
 }
 
-func (s *DeviceState) Unprepare(claimUID string) error {
+func (s *DeviceState) Unprepare(claimUID string) (bool, error) {
 	s.Lock()
 	defer s.Unlock()
 
 	checkpoint := newCheckpoint()
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
-		return fmt.Errorf("unable to sync from checkpoint: %v", err)
+		return false, fmt.Errorf("unable to sync from checkpoint: %v", err)
 	}
 	preparedClaims := checkpoint.V1.PreparedClaims
 
 	if preparedClaims[claimUID] == nil {
-		return nil
+		return false, nil
 	}
 
-	if err := s.unprepareDevices(claimUID, preparedClaims[claimUID]); err != nil {
-		return fmt.Errorf("unprepare failed: %v", err)
+	devices := preparedClaims[claimUID]
+	if err := s.unprepareDevices(claimUID, devices); err != nil {
+		return false, fmt.Errorf("unprepare failed: %v", err)
+	}
+
+	siblingChanged := false
+	for _, pd := range devices {
+		if allocDev, exists := s.allocatable[pd.DeviceName]; exists {
+			if allocDev.GetSiblingLookupPCIAddress() != "" {
+				s.RestoreSiblingDevices(allocDev)
+				siblingChanged = true
+			}
+		}
 	}
 
 	err := s.cdi.DeleteClaimSpecFile(claimUID)
 	if err != nil {
-		return fmt.Errorf("unable to delete CDI spec file for claim: %v", err)
+		return siblingChanged, fmt.Errorf("unable to delete CDI spec file for claim: %v", err)
 	}
 
 	delete(preparedClaims, claimUID)
 	if err := s.checkpointManager.CreateCheckpoint(DriverPluginCheckpointFile, checkpoint); err != nil {
-		return fmt.Errorf("unable to sync to checkpoint: %v", err)
+		return siblingChanged, fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 
-	return nil
+	return siblingChanged, nil
 }
 
 func (s *DeviceState) prepareDevices(claim *resourceapi.ResourceClaim) (PreparedDevices, error) {
@@ -405,6 +437,49 @@ func (s *DeviceState) restoreFromVfio(deviceName string) {
 		klog.Infof("Restored %s from VFIO back to AmdGpu type", deviceName)
 	}
 	delete(s.claimVfioConversions, deviceName)
+}
+
+func (s *DeviceState) buildPCIIndex() {
+	s.byPCIAddress = make(map[string][]string)
+	for name, dev := range s.allocatable {
+		pci := dev.GetSiblingLookupPCIAddress()
+		if pci != "" {
+			s.byPCIAddress[pci] = append(s.byPCIAddress[pci], name)
+		}
+	}
+}
+
+func (s *DeviceState) RemoveSiblingDevices(devName string, device *AllocatableDevice) {
+	pci := device.GetSiblingLookupPCIAddress()
+	if pci == "" {
+		return
+	}
+	for _, name := range s.byPCIAddress[pci] {
+		if name == devName {
+			continue
+		}
+		if sibling, exists := s.allocatable[name]; exists {
+			s.siblingCache[name] = sibling
+			delete(s.allocatable, name)
+			klog.Infof("Removed sibling %s (type %s) for prepared device %s", name, sibling.Type(), devName)
+		}
+	}
+}
+
+func (s *DeviceState) RestoreSiblingDevices(device *AllocatableDevice) {
+	pci := device.GetSiblingLookupPCIAddress()
+	if pci == "" {
+		return
+	}
+	for name, cached := range s.siblingCache {
+		cachedPCI := cached.GetSiblingLookupPCIAddress()
+		if cachedPCI == pci {
+			s.allocatable[name] = cached
+			delete(s.siblingCache, name)
+			klog.Infof("Restored sibling %s (type %s) after unprepare", name, cached.Type())
+		}
+	}
+	s.buildPCIIndex()
 }
 
 // getDeviceAttrs gets the major, minor, type, and permissions for a given device path.

--- a/cmd/gpu-kubeletplugin/state_test.go
+++ b/cmd/gpu-kubeletplugin/state_test.go
@@ -143,6 +143,122 @@ func TestUnprepareDevices_PreDiscoveredVfioNotRestored(t *testing.T) {
 	assert.Nil(t, allocDev.AmdGpu, "should not gain an AmdGpu entry")
 }
 
+func TestRemoveAndRestoreSiblingDevices(t *testing.T) {
+	pciAddr := "0000:0a:00.0"
+	computeDev := &AllocatableDevice{AmdGpu: &AmdGpuInfo{PCIAddress: pciAddr, cardIndex: 0, renderIndex: 128}}
+	vfioDev := &AllocatableDevice{Vfio: &AmdGpuVFIOInfo{
+		PCIAddress:  pciAddr,
+		IsVF:        false,
+		Index:       0,
+		MemoryBytes: 206158430208,
+	}}
+
+	state := &DeviceState{
+		allocatable: AllocatableDevices{
+			"gpu-0-128":  computeDev,
+			"gpu-vfio-0": vfioDev,
+		},
+		siblingCache: make(AllocatableDevices),
+	}
+	state.buildPCIIndex()
+
+	state.RemoveSiblingDevices("gpu-0-128", computeDev)
+	assert.Contains(t, state.allocatable, "gpu-0-128")
+	assert.NotContains(t, state.allocatable, "gpu-vfio-0")
+	assert.Contains(t, state.siblingCache, "gpu-vfio-0")
+
+	state.RestoreSiblingDevices(computeDev)
+	assert.Contains(t, state.allocatable, "gpu-0-128")
+	assert.Contains(t, state.allocatable, "gpu-vfio-0")
+	assert.NotContains(t, state.siblingCache, "gpu-vfio-0")
+}
+
+func TestSiblingCachePreservesCapacity(t *testing.T) {
+	pciAddr := "0000:0a:00.0"
+	computeDev := &AllocatableDevice{AmdGpu: &AmdGpuInfo{PCIAddress: pciAddr, cardIndex: 0, renderIndex: 128}}
+	vfioDev := &AllocatableDevice{Vfio: &AmdGpuVFIOInfo{
+		PCIAddress:   pciAddr,
+		IsVF:         false,
+		Index:        0,
+		MemoryBytes:  206158430208,
+		ComputeUnits: 304,
+		SimdUnits:    1216,
+	}}
+
+	state := &DeviceState{
+		allocatable: AllocatableDevices{
+			"gpu-0-128":  computeDev,
+			"gpu-vfio-0": vfioDev,
+		},
+		siblingCache: make(AllocatableDevices),
+	}
+	state.buildPCIIndex()
+
+	state.RemoveSiblingDevices("gpu-0-128", computeDev)
+	state.RestoreSiblingDevices(computeDev)
+
+	restored := state.allocatable["gpu-vfio-0"]
+	assert.Equal(t, uint64(206158430208), restored.Vfio.MemoryBytes)
+	assert.Equal(t, 304, restored.Vfio.ComputeUnits)
+	assert.Equal(t, 1216, restored.Vfio.SimdUnits)
+}
+
+func TestRemoveSiblingDevices_NoSiblings(t *testing.T) {
+	dev := &AllocatableDevice{AmdGpu: &AmdGpuInfo{PCIAddress: "0000:0a:00.0", cardIndex: 0, renderIndex: 128}}
+	state := &DeviceState{
+		allocatable: AllocatableDevices{
+			"gpu-0-128": dev,
+		},
+		siblingCache: make(AllocatableDevices),
+	}
+	state.buildPCIIndex()
+
+	assert.NotPanics(t, func() {
+		state.RemoveSiblingDevices("gpu-0-128", dev)
+	})
+	assert.Contains(t, state.allocatable, "gpu-0-128")
+	assert.Empty(t, state.siblingCache)
+}
+
+func TestRestoreSiblingDevices_EmptyCache(t *testing.T) {
+	dev := &AllocatableDevice{AmdGpu: &AmdGpuInfo{PCIAddress: "0000:0a:00.0", cardIndex: 0, renderIndex: 128}}
+	state := &DeviceState{
+		allocatable: AllocatableDevices{
+			"gpu-0-128": dev,
+		},
+		siblingCache: make(AllocatableDevices),
+	}
+	state.buildPCIIndex()
+
+	assert.NotPanics(t, func() {
+		state.RestoreSiblingDevices(dev)
+	})
+	assert.Contains(t, state.allocatable, "gpu-0-128")
+}
+
+func TestBuildPCIIndex(t *testing.T) {
+	state := &DeviceState{
+		allocatable: AllocatableDevices{
+			"gpu-0-128":  {AmdGpu: &AmdGpuInfo{PCIAddress: "0000:0a:00.0", cardIndex: 0, renderIndex: 128}},
+			"gpu-vfio-0": {Vfio: &AmdGpuVFIOInfo{PCIAddress: "0000:0a:00.0", IsVF: false, Index: 0}},
+			"gpu-vfio-1": {Vfio: &AmdGpuVFIOInfo{PCIAddress: "0000:0b:00.0", IsVF: true, Index: 1}},
+			"gpu-1-129":  {AmdPartition: &AmdPartitionInfo{Parent: &AmdGpuInfo{PCIAddress: "0000:0c:00.0"}, cardIndex: 1, renderIndex: 129}},
+		},
+		siblingCache: make(AllocatableDevices),
+	}
+	state.buildPCIIndex()
+
+	assert.Len(t, state.byPCIAddress["0000:0a:00.0"], 2, "compute GPU and VFIO PF share PCI address")
+	assert.Contains(t, state.byPCIAddress["0000:0a:00.0"], "gpu-0-128")
+	assert.Contains(t, state.byPCIAddress["0000:0a:00.0"], "gpu-vfio-0")
+
+	_, hasVF := state.byPCIAddress["0000:0b:00.0"]
+	assert.False(t, hasVF, "VFIO VF should not be indexed (returns empty PCI address)")
+
+	_, hasPartition := state.byPCIAddress["0000:0c:00.0"]
+	assert.False(t, hasPartition, "AmdPartition should not be indexed")
+}
+
 func TestPreparedDevicesGetDevices(t *testing.T) {
 	tests := map[string]struct {
 		preparedDevices PreparedDevices

--- a/docs/driver-attributes.md
+++ b/docs/driver-attributes.md
@@ -224,8 +224,13 @@ selectors:
 
 ## VFIO passthrough devices
 
-When the `VFIOPassthrough` feature gate is enabled, the driver discovers GIM
-SR-IOV VFs and advertises them as VFIO passthrough devices with `type = vfio`.
+When the `VFIOPassthrough` feature gate is enabled, the driver advertises VFIO
+passthrough devices with `type = vfio`. These come from two sources:
+
+1. **Dual-entry siblings** — each compute GPU (`type=amdgpu`) also appears as a
+   VFIO device (`type=vfio`) for PF passthrough.
+2. **GIM SR-IOV VFs** — VFs created by the GIM driver appear as VFIO devices
+   with `isVF=true`.
 
 ### Attributes for a VFIO device
 
@@ -239,9 +244,24 @@ SR-IOV VFs and advertises them as VFIO passthrough devices with `type = vfio`.
 | `productName` | string | GPU product name (e.g., `Instinct_MI300X`) |
 | `deviceID` | string | PCI device ID (e.g., `0x740f`) |
 | `vendorID` | string | PCI vendor ID (`0x1002` for AMD) |
+| `partitionProfile` | string | Compute partition mode (e.g., `cpx`, `qpx`, `tpx`, `dpx`, `spx`). Only present on GIM VFs with a recognized partition mode. Not set on dual-entry PF siblings. |
 
 Standard topology attributes (`resource.kubernetes.io/pciBusID`,
 `resource.kubernetes.io/pcieRoot`) are also published when available.
+
+### Capacity for VFIO devices
+
+GIM VFs publish per-VF capacity computed as the PF's total capacity divided
+equally by the number of active VFs:
+
+- `memory` (quantity, bytes): PF VRAM / NumVFs
+- `computeUnits` (quantity): PF CUs / NumVFs
+- `simdUnits` (quantity): PF SIMDs / NumVFs
+
+Dual-entry PF siblings publish the full PF capacity. Pre-bound PF-passthrough
+devices (already on `vfio-pci` at discovery) have no capacity data.
+
+The capacity map is omitted entirely when all three values are zero.
 
 ### Selecting VFIO devices
 
@@ -252,6 +272,39 @@ selectors:
       device.driver == 'gpu.amd.com' &&
       device.attributes['gpu.amd.com'].type == 'vfio'
 ```
+
+### Dual-entry advertising and sibling exclusion
+
+When `VFIOPassthrough` is enabled, each compute GPU appears in the ResourceSlice
+as both a compute device (`type=amdgpu`) and a VFIO device (`type=vfio`). The
+scheduler allocates whichever type the claim requests.
+
+Sibling exclusion is bidirectional: allocating either type removes the other
+from the ResourceSlice until the claim is released. For example, allocating a
+GPU as `type=vfio` makes the corresponding `type=amdgpu` entry unavailable, and
+vice versa.
+
+Pre-bound PF-passthrough devices (GPUs already bound to `vfio-pci` at discovery
+time, e.g., by the GPU Operator) are different. They appear as VFIO-only
+devices with no compute sibling, no SharedCounters, and no sibling exclusion.
+
+### KEP-4815 SharedCounters for PF/VF mutual exclusion
+
+For GPUs with SR-IOV capability (`TotalVFs > 0`), the driver publishes a
+`SharedCounterSet` per PF to prevent over-subscription of VFs and enforce
+mutual exclusion between PF and VF allocation.
+
+- **Counter set name:** `pf-<pci-addr>-counter-set` (PCI address in DNS label
+  form, e.g., `pf-0000-0a-00-0-counter-set`)
+- **Counter:** `vf-slots` with value equal to `TotalVFs`
+- **VF consumption:** each VF consumes 1 `vf-slot`
+- **PF consumption:** the PF consumes `TotalVFs` slots (the entire budget)
+
+This means allocating the PF as a VFIO device exhausts all slots, preventing
+any VF from being allocated on the same physical GPU. Conversely, if all VF
+slots are consumed by VF allocations, the PF cannot be allocated.
+
+Non-SR-IOV GPUs (`TotalVFs = 0`) do not publish counter sets.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -177,6 +177,34 @@ spec:
 The driver binds the allocated VF to `vfio-pci` during Prepare and unbinds
 on release. VFIO devices appear in the ResourceSlice with `type = vfio`.
 
+**Dual-entry advertising:**
+
+When `VFIOPassthrough` is enabled, each compute GPU also appears as a
+`type=vfio` device in the ResourceSlice. You can claim a VFIO GPU directly
+by selecting `type=vfio` without using a `VfioDeviceConfig`:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: gpu-vfio-direct
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.amd.com
+        selectors:
+        - cel:
+            expression: 'device.attributes["gpu.amd.com"].type == "vfio"'
+```
+
+This is the simpler path for VFIO allocation. The `VfioDeviceConfig` approach
+(shown above) is still supported for on-demand conversion of compute GPUs.
+
+When either the compute or VFIO entry is allocated, the other is temporarily
+removed from the ResourceSlice. It returns when the claim is released.
+
 ### Key values
 
 | Value | Default | Description |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -182,6 +182,40 @@ If not loaded: `modprobe vfio_pci`. The driver logs a warning at startup but
 continues without it — pre-bound devices still work, but on-demand binding
 will fail.
 
+### GPU unavailable after VFIO allocation
+
+**Symptom:** A compute GPU (`type=amdgpu`) disappears from the ResourceSlice
+after a VFIO device on the same physical GPU is allocated.
+
+**Cause:** This is expected behavior. Dual-entry advertising creates both a
+compute and a VFIO entry for each GPU. Sibling exclusion is bidirectional:
+allocating either type removes the other from the ResourceSlice to prevent
+the same physical GPU from being used for both compute and passthrough
+simultaneously.
+
+**Resolution:** The sibling returns to the ResourceSlice when the claim is
+released. No action is needed. To verify:
+
+```bash
+kubectl get resourceslices -o json | jq '.items[].spec.devices[].basic.attributes["gpu.amd.com"].type'
+```
+
+### VFIO device cannot be allocated — VF slots exhausted
+
+**Symptom:** A ResourceClaim for a VFIO device stays Pending even though
+VFIO devices appear in the ResourceSlice.
+
+**Cause:** All `vf-slots` counters for the PF are consumed by existing
+allocations. The scheduler cannot allocate more VFs (or the PF) until
+slots are freed.
+
+**Resolution:**
+1. Check counter consumption: `kubectl get resourceslices -o yaml` and
+   look for `sharedCounters` and `consumesCounters` entries.
+2. Release existing VFIO claims to free slots.
+3. If a PF is allocated (consuming all slots), no VFs can be allocated
+   until the PF claim is released.
+
 ### Device stuck on vfio-pci after VM deletion
 
 If `Unconfigure` fails during Unprepare, the device remains bound to `vfio-pci`.

--- a/pkg/amdgpu/vfio.go
+++ b/pkg/amdgpu/vfio.go
@@ -143,6 +143,30 @@ type VFInfo struct {
 	ProductName string
 	// NumaNode is the NUMA node affinity.
 	NumaNode int
+	TotalVFs int
+	NumVFs   int
+}
+
+func readSysfsInt(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	var val int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &val); err != nil {
+		return 0
+	}
+	return val
+}
+
+// ReadSRIOVTotalVFs reads the maximum number of SR-IOV VFs supported by a PF.
+func ReadSRIOVTotalVFs(pfPCIAddress string) int {
+	return readSysfsInt(filepath.Join(PCIDevicePath, pfPCIAddress, "sriov_totalvfs"))
+}
+
+// ReadSRIOVNumVFs reads the number of SR-IOV VFs currently active on a PF.
+func ReadSRIOVNumVFs(pfPCIAddress string) int {
+	return readSysfsInt(filepath.Join(PCIDevicePath, pfPCIAddress, "sriov_numvfs"))
 }
 
 // GetVFMapping scans for AMD GPU Virtual Functions created by the GIM SR-IOV
@@ -189,6 +213,8 @@ func GetVFMapping() (map[string][]VFInfo, error) {
 		}
 
 		pfProductName := readProductName(pfAddr)
+		pfTotalVFs := ReadSRIOVTotalVFs(pfAddr)
+		pfNumVFs := ReadSRIOVNumVFs(pfAddr)
 
 		for _, vfPath := range vfPaths {
 			vfTarget, err := os.Readlink(vfPath)
@@ -226,6 +252,8 @@ func GetVFMapping() (map[string][]VFInfo, error) {
 				IOMMUGroup:       iommuGroup,
 				ProductName:      pfProductName,
 				NumaNode:         numaNode,
+				TotalVFs:         pfTotalVFs,
+				NumVFs:           pfNumVFs,
 			}
 			vfMap[iommuGroup] = append(vfMap[iommuGroup], vfInfo)
 			glog.Infof("VFIO VF: PF %s -> VF %s IOMMU group: %s", pfAddr, vfAddr, iommuGroup)
@@ -313,6 +341,34 @@ func readSysfsFile(path string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(data)), nil
+}
+
+// ReadPFCapacity reads the total memory for a GIM-managed PF from sysfs.
+// Returns [memoryBytes, cuCount, simdCount]. CU and SIMD counts are inferred
+// from the PF device ID since GIM does not expose topology files.
+func ReadPFCapacity(pfAddr string) [3]uint64 {
+	var mem uint64
+	memStr, _ := readSysfsFile(filepath.Join(PCIDevicePath, pfAddr, "mem_info_vram_total"))
+	if memStr != "" {
+		fmt.Sscanf(memStr, "%d", &mem)
+	}
+	deviceID, _ := readSysfsFile(filepath.Join(PCIDevicePath, pfAddr, "device"))
+	cu, simd := gpuCapacityByDeviceID(deviceID)
+	return [3]uint64{mem, uint64(cu), uint64(simd)}
+}
+
+// gpuCapacityByDeviceID returns (cuCount, simdCount) for known AMD GPU PF device IDs.
+func gpuCapacityByDeviceID(deviceID string) (int, int) {
+	switch deviceID {
+	case "0x75a3": // MI355X PF — 8 XCCs, 32 CU/XCC, 4 SIMD/CU
+		return 256, 1024
+	case "0x740f": // MI300X PF — 8 XCCs, 32 CU/XCC, 4 SIMD/CU
+		return 304, 1216
+	case "0x74a0": // MI325X PF — 8 XCCs, 38 CU/XCC, 4 SIMD/CU
+		return 304, 1216
+	default:
+		return 0, 0
+	}
 }
 
 // readProductName reads the product_name from sysfs for a PCI device.

--- a/pkg/amdgpu/vfio_test.go
+++ b/pkg/amdgpu/vfio_test.go
@@ -281,6 +281,91 @@ func TestGetVFMapping(t *testing.T) {
 	})
 }
 
+func TestReadSRIOVNumVFs(t *testing.T) {
+	tests := map[string]struct {
+		fileContent string
+		createFile  bool
+		expected    int
+	}{
+		"8 VFs active": {fileContent: "8\n", createFile: true, expected: 8},
+		"4 VFs active": {fileContent: "4\n", createFile: true, expected: 4},
+		"1 VF active":  {fileContent: "1\n", createFile: true, expected: 1},
+		"0 VFs active": {fileContent: "0\n", createFile: true, expected: 0},
+		"file missing": {createFile: false, expected: 0},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := setupFakeSysfs(t)
+			pciAddr := "0000:0a:00.0"
+			files := map[string]string{}
+			if tc.createFile {
+				files["sriov_numvfs"] = tc.fileContent
+			}
+			createFakePCIDevice(t, root, pciAddr, files, nil)
+			assert.Equal(t, tc.expected, ReadSRIOVNumVFs(pciAddr))
+		})
+	}
+}
+
+func TestReadPFCapacity(t *testing.T) {
+	t.Run("all files present", func(t *testing.T) {
+		root := setupFakeSysfs(t)
+		pciAddr := "0000:0a:00.0"
+		createFakePCIDevice(t, root, pciAddr, map[string]string{
+			"mem_info_vram_total": "206158430208\n",
+			"device":              "0x740f",
+		}, nil)
+		cap := ReadPFCapacity(pciAddr)
+		assert.Equal(t, uint64(206158430208), cap[0])
+		assert.Equal(t, uint64(304), cap[1])
+		assert.Equal(t, uint64(1216), cap[2])
+	})
+
+	t.Run("unknown device ID", func(t *testing.T) {
+		root := setupFakeSysfs(t)
+		pciAddr := "0000:0a:00.0"
+		createFakePCIDevice(t, root, pciAddr, map[string]string{
+			"mem_info_vram_total": "1000000\n",
+			"device":              "0x9999",
+		}, nil)
+		cap := ReadPFCapacity(pciAddr)
+		assert.Equal(t, uint64(1000000), cap[0])
+		assert.Equal(t, uint64(0), cap[1])
+		assert.Equal(t, uint64(0), cap[2])
+	})
+
+	t.Run("missing files", func(t *testing.T) {
+		root := setupFakeSysfs(t)
+		pciAddr := "0000:0a:00.0"
+		createFakePCIDevice(t, root, pciAddr, nil, nil)
+		cap := ReadPFCapacity(pciAddr)
+		assert.Equal(t, [3]uint64{0, 0, 0}, cap)
+	})
+}
+
+func TestGpuCapacityByDeviceID(t *testing.T) {
+	tests := map[string]struct {
+		deviceID     string
+		expectedCU   int
+		expectedSIMD int
+	}{
+		"MI355X":  {deviceID: "0x75a3", expectedCU: 256, expectedSIMD: 1024},
+		"MI300X":  {deviceID: "0x740f", expectedCU: 304, expectedSIMD: 1216},
+		"MI325X":  {deviceID: "0x74a0", expectedCU: 304, expectedSIMD: 1216},
+		"unknown": {deviceID: "0x9999", expectedCU: 0, expectedSIMD: 0},
+		"empty":   {deviceID: "", expectedCU: 0, expectedSIMD: 0},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cu, simd := gpuCapacityByDeviceID(tc.deviceID)
+			assert.Equal(t, tc.expectedCU, cu)
+			assert.Equal(t, tc.expectedSIMD, simd)
+		})
+	}
+}
+
 func TestGetPFMapping(t *testing.T) {
 	t.Run("PF on vfio-pci discovered", func(t *testing.T) {
 		root := setupFakeSysfs(t)


### PR DESCRIPTION
## Summary

Closes #89. Adds KEP-4815 dual-entry advertising, per-VF capacity, and sibling mutual exclusion for VFIO passthrough, building on PR #50.

- **Dual-entry advertising:** Each compute GPU is advertised as both `type=amdgpu` (compute) and `type=vfio` (passthrough) in the ResourceSlice, behind the `VFIOPassthrough` feature gate. The scheduler explicitly allocates either type.
- **KEP-4815 SharedCounters:** Each SR-IOV PF publishes a `SharedCounterSet` with a `vf-slots` counter. VFs consume 1 slot; PFs consume all slots (mutual exclusion). Non-SR-IOV GPUs get no counter set.
- **Sibling exclusion:** On Prepare, `RemoveSiblingDevices` removes the sibling type from the ResourceSlice. On Unprepare, `RestoreSiblingDevices` re-adds it. ResourceSlice is republished after each change.
- **Per-VF capacity:** VFs publish `memory`, `computeUnits`, `simdUnits` (PF totals divided by NumVFs). Partition mode (SPX/DPX/QPX/CPX) is inferred from NumVFs and published as `partitionProfile`.
- **Bug fixes:** Data race in `republishResources` (now acquires state lock), VFIO conversion name mismatch in `RemoveSiblingDevices` (now takes explicit map key), spurious counter sets for non-SR-IOV GPUs removed.
- **Unit tests:** Comprehensive tests for partition mode, counter sets, sibling management, PCI index, sysfs helpers, allocatable lookups, and driver resource building.

## Changes

| File | Change |
|---|---|
| `deviceinfo.go` | `AmdGpuVFIOInfo` fields (NumVFs, capacity), `partitionMode()`, KEP-4815 counter methods |
| `discovery.go` | VFIO sibling creation per compute GPU, VF capacity from `ReadPFCapacity` |
| `state.go` | `RemoveSiblingDevices`/`RestoreSiblingDevices`, `buildPCIIndex`, checkpoint rollback |
| `driver.go` | `collectVFIOCounterSets`, `republishResources` with state lock, `buildDriverResources` with counters |
| `allocatable.go` | `GetSiblingLookupPCIAddress` for sibling lookup |
| `pkg/amdgpu/vfio.go` | `ReadSRIOVNumVFs`, `ReadPFCapacity`, `gpuCapacityByDeviceID`, `readSysfsInt` |
| `*_test.go` (6 files) | ~480 lines of new tests |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all new + existing tests)
- [x] `go vet ./...` clean
- [ ] Hardware validation on MI300X/MI355X with GIM SR-IOV (requires physical hardware)
- [ ] KubeVirt VM passthrough with dual-entry allocation